### PR TITLE
Enable clang-format as a code formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,207 @@
-BasedOnStyle: LLVM
-BreakBeforeBraces: Linux
-UseTab: Never
-IndentWidth: 4
-TabWidth: 4
-ColumnLimit: 0
+---
+# Target: clang-format 18
+
+# BasedOnStyle: Chromium
+Language: Cpp
+Standard: c++11
+
 AccessModifierOffset: -4
-AllowShortIfStatementsOnASingleLine: Always
-AlignAfterOpenBracket: DontAlign
-BreakConstructorInitializers: AfterColon
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+AlignConsecutiveBitFields:
+  Enabled:         false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+AlignConsecutiveMacros:
+  Enabled:         false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowBreakBeforeNoexceptSpecifier: OnlyWithParen
+AllowShortBlocksOnASingleLine: Empty
+# v19 - AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+# v20 - AllowShortNamespacesOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AttributeMacros:
+BinPackArguments: true
+# v21 - BinPackLongBracedList: false
+BinPackParameters: false # Equivalent to OnePerLine in newer versions
+BitFieldColonSpacing: Both
+BracedInitializerIndentWidth: 4
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: MultiLine
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+# v19 - BreakAfterReturnType: Automatic
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+# v21 - BreakBeforeTemplateCloser: false
+BreakBeforeTernaryOperators: true
+# v20 - BreakBinaryOperations: Never
+BreakConstructorInitializers: BeforeColon
+# v19 - BreakFunctionDefinitionParameters: false
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+# v19 - BreakTemplateDeclarations: Yes
+
+# Examples in the wild:
+# - Linux: 80
+# - Google: 80
+# - Python (PEP 8): 80
+# - Python (black): 88
+# - Others: 100, 120, None
+#
+# Coders should strive to keep lines < 80 by:
+# - Reducing nesting with functions and early returns
+# - Reducing function argument count
+# - Using named variables for clarity
+ColumnLimit:     90
+
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+# v21 - EnumTrailingComma: Leave
+FixNamespaceComments: true
+ForEachMacros:
+IfMacros:
+IncludeBlocks:   Preserve
+IncludeCategories:
+IncludeIsMainRegex: '([-_](test))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+# v20 - IndentExportBlock: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  # Disable until C++14
+  Binary:           0
+  # Binary:           4
+  BinaryMinDigits:  5
+  Decimal:          0
+  # Decimal:          3
+  DecimalMinDigits: 6
+  Hex:              0
+  # Hex:              4
+  HexMinDigits:     5
+# Replaced with v19 versions below
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+# v19 - KeepEmptyLines:
+# v19 -   AtEndOfFile:     false
+# v19 -   AtStartOfBlock:  true
+# v19 -   AtStartOfFile:   false
+# v20 - KeepFormFeed:    false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+# v19 - MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-IndentCaseLabels: true
-SortIncludes: Never
+PackConstructorInitializers: NextLine
+
+# Use default Penalty* costs
+# PenaltyBreakAssignment: 2
+# Penalty*: ...
+
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - cpp
+    CanonicalDelimiter: 'cc'
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+# v20 - RemoveEmptyLinesInUnwrappedLines: true
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseSensitive
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+# v21 - SpaceAfterOperatorKeyword: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInSquareBrackets: false
+StatementAttributeLikeMacros:
+StatementMacros:
+TabWidth:        4
+UseTab:          Never
+WhitespaceSensitiveMacros:
+# v20 - WrapNamespaceBodyWithEmptyLines: Leave
+...

--- a/.clang-format
+++ b/.clang-format
@@ -72,7 +72,7 @@ BreakBeforeInlineASMColon: OnlyMultiline
 # v21 - BreakBeforeTemplateCloser: false
 BreakBeforeTernaryOperators: true
 # v20 - BreakBinaryOperations: Never
-BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializers: AfterColon
 # v19 - BreakFunctionDefinitionParameters: false
 BreakInheritanceList: AfterColon
 BreakStringLiterals: false
@@ -110,7 +110,7 @@ IncludeIsMainRegex: '([-_](test))?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
 IndentCaseBlocks: false
-IndentCaseLabels: false
+IndentCaseLabels: true
 # v20 - IndentExportBlock: false
 IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
@@ -119,7 +119,7 @@ IndentRequiresClause: true
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 InsertBraces:    false
-InsertNewlineAtEOF: false
+InsertNewlineAtEOF: true
 InsertTrailingCommas: None
 IntegerLiteralSeparator:
   Binary:           4
@@ -160,7 +160,7 @@ RawStringFormats:
     CanonicalDelimiter: 'cc'
     BasedOnStyle:    google
 ReferenceAlignment: Pointer
-ReflowComments:  true
+ReflowComments:  false
 RemoveBracesLLVM: false
 # v20 - RemoveEmptyLinesInUnwrappedLines: true
 RemoveParentheses: Leave

--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,203 @@
-BasedOnStyle: LLVM
-BreakBeforeBraces: Linux
-UseTab: Never
-IndentWidth: 4
-TabWidth: 4
-ColumnLimit: 0
+---
+# Target: clang-format 18
+
+# BasedOnStyle: Chromium
+Language: Cpp
+Standard: c++17
+
 AccessModifierOffset: -4
-AllowShortIfStatementsOnASingleLine: Always
-AlignAfterOpenBracket: DontAlign
-BreakConstructorInitializers: AfterColon
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+AlignConsecutiveBitFields:
+  Enabled:         false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+AlignConsecutiveMacros:
+  Enabled:         false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowBreakBeforeNoexceptSpecifier: OnlyWithParen
+AllowShortBlocksOnASingleLine: Empty
+# v19 - AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+# v20 - AllowShortNamespacesOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AttributeMacros:
+BinPackArguments: true
+# v21 - BinPackLongBracedList: false
+BinPackParameters: false # Equivalent to OnePerLine in newer versions
+BitFieldColonSpacing: Both
+BracedInitializerIndentWidth: 4
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: MultiLine
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+# v19 - BreakAfterReturnType: Automatic
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+# v21 - BreakBeforeTemplateCloser: false
+BreakBeforeTernaryOperators: true
+# v20 - BreakBinaryOperations: Never
+BreakConstructorInitializers: BeforeColon
+# v19 - BreakFunctionDefinitionParameters: false
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+# v19 - BreakTemplateDeclarations: Yes
+
+# Examples in the wild:
+# - Linux: 80
+# - Google: 80
+# - Python (PEP 8): 80
+# - Python (black): 88
+# - Others: 100, 120, None
+#
+# Coders should strive to keep lines < 80 by:
+# - Reducing nesting with functions and early returns
+# - Reducing function argument count
+# - Using named variables for clarity
+ColumnLimit:     90
+
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+# v21 - EnumTrailingComma: Leave
+FixNamespaceComments: true
+ForEachMacros:
+IfMacros:
+IncludeBlocks:   Preserve
+IncludeCategories:
+IncludeIsMainRegex: '([-_](test))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+# v20 - IndentExportBlock: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:           4
+  BinaryMinDigits:  5
+  Decimal:          3
+  DecimalMinDigits: 6
+  Hex:              4
+  HexMinDigits:     5
+# Replaced with v19 versions below
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+# v19 - KeepEmptyLines:
+# v19 -   AtEndOfFile:     false
+# v19 -   AtStartOfBlock:  true
+# v19 -   AtStartOfFile:   false
+# v20 - KeepFormFeed:    false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+# v19 - MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-IndentCaseLabels: true
-SortIncludes: Never
+PackConstructorInitializers: NextLine
+
+# Use default Penalty* costs
+# PenaltyBreakAssignment: 2
+# Penalty*: ...
+
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - cpp
+    CanonicalDelimiter: 'cc'
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+# v20 - RemoveEmptyLinesInUnwrappedLines: true
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseSensitive
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+# v21 - SpaceAfterOperatorKeyword: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInSquareBrackets: false
+StatementAttributeLikeMacros:
+StatementMacros:
+TabWidth:        4
+UseTab:          Never
+WhitespaceSensitiveMacros:
+# v20 - WrapNamespaceBodyWithEmptyLines: Leave
+...

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,20 @@
+# Don't format external/library code
+rtengine/cJSON.*
+rtengine/dcraw.*
+rtengine/jdatasrc.cc
+rtengine/jpeg.h
+rtengine/jpeg_ijg/*
+rtengine/klt/*
+rtengine/libraw/*
+rtengine/libraw/**/*
+rtengine/libraw/**/**/*
+
+# Blacklist all while transitioning to clang-format
+rtengine/*
+rtgui/*
+rtgui/widgets/*
+rtgui/widgets/basic/*
+rtgui/widgets/curves/*
+rtgui/windows/*
+rtgui/tools/*
+tools/gimp-plugin/*

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,8 @@
+# Don't format external/library code
+external/*
+rtengine/dcraw.*
+
+# Blacklist all while transitioning to clang-format
+rtengine/*
+rtgui/*
+tools/gimp-plugin/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,4 @@ The most useful feedback is based on the latest development code, and in the cas
 - Keep branches small so that completed and working features can be merged into the "dev" branch often, and so that they can be abandoned if they head in the wrong direction.
 - Documentation for your work must be provided in order for your branch to be merged if it changes or adds anything the user should know about. The documentation can be provided in plain-text or markdown form as a comment in the issue or pull request.
 - Use C++11.
-- To break header dependencies use forward declarations as much as possible. See [#5197](https://github.com/RawTherapee/RawTherapee/pull/5197#issuecomment-468938190) for some tips.
-- The naming isn't homogeneous throughout the code but here is a rough guideline:
-  - *Identifiers* (variables, functions, methods, keys, enums, etc.) should be clear and unambiguous. Make them as long as necessary to ensure that your code is understandable to others.
-  - *Types* (classes, structs, enums, typedefs...) should be named with `UpperCamelCase`.
-  - *Functions* and *methods* should be named with `lowerCamelCase`.
-  - *Variables* should be either named with `lowerCamelCase` or better with `lower_underscores` to avoid conflicts.
-  - *Enum values* should be named with `UPPER_UNDERSCORES`.
-  - Be consistent, even when not sticking to the rules.
-- Code may be run through astyle version 3 or newer. If using astyle, it is important that the astyle changes go into their own commit, so that style changes are not mixed with actual code changes. Command: `astyle --options=rawtherapee.astylerc code.cc`
+- Follow [coding conventions](/devnotes/coding-conventions.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,4 @@ The most useful feedback is based on the latest development code, and in the cas
 - Keep branches small so that completed and working features can be merged into the "dev" branch often, and so that they can be abandoned if they head in the wrong direction.
 - Documentation for your work must be provided in order for your branch to be merged if it changes or adds anything the user should know about. The documentation can be provided in plain-text or markdown form as a comment in the issue or pull request.
 - Use C++17 (see [allowed features](devnotes/cpp.md))
-- To break header dependencies use forward declarations as much as possible. See [#5197](https://github.com/RawTherapee/RawTherapee/pull/5197#issuecomment-468938190) for some tips.
-- The naming isn't homogeneous throughout the code but here is a rough guideline:
-  - *Identifiers* (variables, functions, methods, keys, enums, etc.) should be clear and unambiguous. Make them as long as necessary to ensure that your code is understandable to others.
-  - *Types* (classes, structs, enums, typedefs...) should be named with `UpperCamelCase`.
-  - *Functions* and *methods* should be named with `lowerCamelCase`.
-  - *Variables* should be either named with `lowerCamelCase` or better with `lower_underscores` to avoid conflicts.
-  - *Enum values* should be named with `UPPER_UNDERSCORES`.
-  - Be consistent, even when not sticking to the rules.
-- Code may be run through astyle version 3 or newer. If using astyle, it is important that the astyle changes go into their own commit, so that style changes are not mixed with actual code changes. Command: `astyle --options=rawtherapee.astylerc code.cc`
+- Follow [coding conventions](/devnotes/coding-conventions.md).

--- a/devnotes/coding-conventions.md
+++ b/devnotes/coding-conventions.md
@@ -115,3 +115,238 @@ uv tool run black YOUR_SCRIPT.py
 # Run the script and uv will manage/install dependencies automatically
 uv run YOUR_SCRIPT.py
 ```
+
+## Coding Style Tips
+
+Treat the following recommendations as soft/loose guidelines that will improve
+the quality of new and refactored code.
+
+### Language Agnostic Tips
+
+#### Function Length
+
+Functions shouldn't be too long. No one likes reading/debugging a 1000+ line
+function that does 20 different things. It can also cause issues for variable
+scoping, compiler optimizations, and debuggers.
+
+A good length for functions is usually < 100 lines, but they can be longer if
+subdividing the function into smaller ones hurts readability.
+
+If your function is long and has separate blocks of tasks, you can extract the
+blocks into their own functions and call them instead.
+
+```cpp
+// Poor
+void run()
+{
+    // Find candidates
+    // ...
+
+    // Process candidates
+    // ...
+
+    // Cleanup
+    // ...
+}
+
+// Better
+void find() {}
+void process() {}
+void cleanup() {}
+
+void run()
+{
+    find();
+    process();
+    cleanup();
+}
+```
+
+#### Guard Clauses/Early Returns
+
+If you have a deeply nested `if` statements, you can reduce nesting by using
+"guard clauses". These work especially well in loops and smaller functions.
+
+```cpp
+// Poor
+void func() {
+    if (a) {
+        if (b) {
+            if (c) {
+                // Do stuff
+            } else {
+                return;
+            }
+        } else {
+            return;
+        }
+    } else {
+        return;
+    }
+}
+
+// Better
+void func() {
+    if (!a) return;
+    if (!b) return;
+    if (!c) return;
+
+    // Do stuff
+}
+```
+
+```cpp
+// Poor
+while (true) {
+    if (a) {
+        if (b) {
+            // Do stuff
+        } else {
+            break;
+        }
+    } else {
+        continue;
+    }
+}
+
+// Better
+while (true) {
+    if (!a) continue;
+    if (!b) break;
+
+    // Do stuff
+}
+```
+
+#### Minimize using magic numbers
+
+"Magic numbers" are hard-coded numeric literals with a special unexplained
+meaning. Some numbers (e.g., 0, 1, 255, 65535) are ok due to being obvious in
+context or easier to understand than a longer variable name. However, when the
+value is more "non-standard" or used in multiple places, understanding and
+modifying the code becomes more difficult and error-prone.
+
+Prefer defining constant variables and using them instead of sprinkling numeric
+literals throughout your code.
+
+```cpp
+enum SCALING_METHOD {
+    NEAREST_NEIGHBOUR = 0,
+    BILINEAR = 1,  // '= 1' is unnecessary as C/C++ automatically increments
+};
+
+constexpr int NEAREST_NEIGHBOUR_SCALING = 0;
+constexpr int BILINEAR_SCALING = 1;
+
+// You can define constants with structs and data structures too.
+constexpr std::array<int, 3> RGB_GREEN = {0, 255, 0};
+```
+
+### C++ Tips
+
+Many concepts here are from the STL. See the [official reference](https://cppreference.com).
+
+#### Memory management
+
+Use smart pointers like `std::unique_ptr` and `std::shared_ptr` instead of raw
+C pointers (e.g. `Foo*`) when modeling ownership. They reduce memory leaks and
+help developers reason about pointer lifetimes.
+
+Prefer using `std::unique_ptr` most of the time as shared ownership (i.e.
+`std::shared_ptr`) is more difficult to reason about. You can return
+`std::unique_ptr` from functions to tell the caller that they need to manage
+the lifetime of the returned pointer. You can also take `std::unique_ptr<T>&&`
+as a function parameter to indicate that the function will take ownership of
+the pointer.
+
+For code that stores a pointer but does not manage the lifetime (i.e. freeing
+the pointer), a simple raw pointer is sufficient. For functions that take raw
+pointers (and don't manage lifetime), a smart pointer can be passed by calling
+the `get()` member function to extract the raw pointer.
+
+This rule is less applicable to GTK code due to the use of `Gtk::managed()`.
+
+#### RAII
+
+C++'s constructors and destructors can be used to simplify and reduce bugs
+related to lifetime management. When an object is constructed, some resource is
+opened. When the object is destroyed, the resource is closed.
+
+Existing examples include smart pointers (e.g. `std::unique_ptr`), file
+handling (e.g. `std::ofstream`), and concurrency
+(`std::lock_guard<std::mutex> lock(mtx)`).
+
+#### Range-based `for` loops
+
+When you want to iterate over a data structure and don't need the index, use
+a range-based `for` loop. This is particularly useful for iterating over arrays
+and lists.
+
+```cpp
+// Good
+for (auto it = vec.begin(); it != vec.end(); it++) {
+    Type& entry = *it;
+    func(entry);
+}
+
+// Better
+for (const auto& entry : vec) {  // Remove const as needed
+    func(entry);
+}
+```
+
+#### Prefer `std::vector` and `std::array` over raw C arrays
+
+Prefer using `std::vector` for dynamically-sized arrays.
+
+Prefer `std::array<T, N> my_array` over `T my_array[N]` for fixed-size
+arrays as it allows C++ utilities like range-based for loops and integration
+with `<algorithm>` header functions.
+
+`std::array` can be passed to functions that need the raw C array by calling
+the `data()` member function.
+
+In most cases, prefer `std::vector` over `std::list` since it is faster due to
+better cache locality.
+
+### `auto` type deduction
+
+`auto` allows the compiler to deduce the type automatically. This may hurt
+readability. It should be used sparingly except for `for` loops, iterators,
+lambdas (and sometimes their arguments), templates, trailing return types, and
+where the deduced type is obvious.
+
+```cpp
+auto ptr = std::make_unique<Foo>();
+auto gtk_box = Gtk::manage(new Box());
+
+std::unordered_map<int> map;
+auto it = map.find(target);
+
+std::vector<int> vec;
+auto start = vec.begin();
+
+for (const auto& it : vec) {}
+
+auto lambda = [](auto arg_type_may_depend_on_lambda_callsite_usage) {};
+```
+
+#### String formatting
+
+Prefer using the more modern [fmt](https://fmt.dev) library for string
+formatting as it is both faster, safer, and more ergonomic. Future C++ versions
+(i.e. C++20 and above) incorporate this library in the STL.
+
+```cpp
+#include <fmt/format.h>
+
+void func()
+{
+    std::string filepath = "foo.jpg";
+    int width = 1920;
+    int height = 1080;
+    std::string text = fmt::format("Image '{}' has dimensions {}x{}",
+                                   filepath, width, height);
+    // Output: Image 'foo.jpg' has dimensions 1920x1080
+}
+```

--- a/devnotes/coding-conventions.md
+++ b/devnotes/coding-conventions.md
@@ -1,0 +1,117 @@
+# Coding Conventions
+
+Try to follow the developer coding conventions. If a file does not follow the
+conventions, try to match existing conventions in the file or local scope.
+Otherwise, stay locally/internally consistent with your own changes.
+
+## C/C++
+
+### Style
+
+- To break header dependencies use forward declarations as much as possible.
+  See [#5197](https://github.com/RawTherapee/RawTherapee/pull/5197#issuecomment-468938190)
+  for some tips.
+- The naming isn't homogeneous throughout the code but here is a rough guideline:
+  - *Identifiers* (variables, functions, methods, keys, enums, etc.) should be clear and unambiguous.
+    - Make them as long as necessary to ensure that your code is understandable to others.
+  - *Types* (classes, structs, enums, typedefs...) should be named with `UpperCamelCase`.
+  - *Functions* and *methods* should be named with `lowerCamelCase`.
+  - *Variables* should be named with `lower_underscores`.
+  - *Enum values*, *constants*, and *macros* should be named with `UPPER_UNDERSCORES`.
+  - Be consistent, even when not sticking to the rules.
+
+### Formatting
+
+#### Old
+
+Some code is formatted using astyle version 3 or newer.
+
+```bash
+astyle --options=rawtherapee.astylerc code.cc
+```
+
+#### New
+
+[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 18
+is used to automatically format files. The files that should be auto-formatted
+can be found in the [.clang-format-ignore](.clang-format-ignore) whitelist.
+
+```bash
+# Run formatting checks
+/path/to/clang-format-18 \
+    --style=file --fallback-style=none \
+    --Werror --ferror-limit=5 \
+    --dry-run FILES...
+
+# Format code in-place
+/path/to/clang-format-18 \
+    --style=file --fallback-style=none \
+    --Werror --ferror-limit=0 \
+    -i FILES...
+
+# Format all using find
+find . -type f \( -name "*.h" -o -name "*.hh" -o -name "*.hpp" -o -name "*.c" -o -name "*.cc" -o -name "*.cpp" \) | \
+    xargs /path/to/clang-format-18 \
+    --style=file --fallback-style=none --Werror --ferror-limit=0 -i
+
+# Format all using [fd](https://github.com/sharkdp/fd)
+fd -e h -e hh -e hpp -e c -e cc -e cpp -X \
+    /path/to/clang-format-18 \
+    --style=file --fallback-style=none --Werror --ferror-limit=0 -i
+```
+
+If your version of clang-format is not 18, you will need to use a package
+manager with the specific version or
+[download the binary](https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.8)
+from official LLVM releases. Download the appropriate `clang+llvm` tarball and
+use the provided standalone `bin/clang-format` executable in it. The 18.1.8
+release has prebuilt binaries for Linux, Windows, and MacOS (ARM). If all else
+fails, you can build clang 18 from source.
+
+The prebuilt clang-format 18.1.8 executable from the LLVM repo may require you
+to install `ncurses5` if you get an error about `libtinfo.so.5`.
+
+### Tips for clang-format
+
+Disable format for a block of code using `// clang-format off/on`
+
+```cpp
+// clang-format off
+keep_formatting_for_this_code();
+// clang-format on
+```
+
+Keep each element of an initializer list on different lines by adding a
+trailing comma.
+
+```cpp
+// If no trailing comma is present, clang-format tends to bin-pack the elements
+// when they exceed the line length limit.
+std::array bin_packed_array = { 0, 1,
+                                2 };
+
+std::array desired_format_array = {
+    0,
+    1,
+    2,  // Trailing comma
+};
+```
+
+## Python
+
+- Follow PEP 8 [naming conventions](https://peps.python.org/pep-0008/#naming-conventions)
+- Format by running [black](https://github.com/psf/black) with default settings
+
+An easy way of running black is to use [uv](https://docs.astral.sh/uv/). It
+also lets you create one-off scripts with extra dependencies.
+
+```bash
+# Create a one-off script that has dependencies managed by uv
+uv init --script YOUR_SCRIPT.py
+# Add dependencies to the script
+uv add --script YOUR_SCRIPT.py numpy onnx
+# Format your code
+uv tool run black YOUR_SCRIPT.py
+# Run the script and uv will manage/install dependencies automatically
+uv run YOUR_SCRIPT.py
+```

--- a/devnotes/coding-conventions.md
+++ b/devnotes/coding-conventions.md
@@ -334,7 +334,8 @@ auto lambda = [](auto arg_type_may_depend_on_lambda_callsite_usage) {};
 
 Prefer using the more modern [fmt](https://fmt.dev) library for string
 formatting as it is both faster, safer, and more ergonomic. Future C++ versions
-(i.e. C++20 and above) incorporate this library in the STL.
+(i.e. C++20 and above) incorporate this library in the STL, but the standalone
+library remains more up-to-date on features, performance, and security.
 
 ```cpp
 #include <fmt/format.h>

--- a/devnotes/coding-conventions.md
+++ b/devnotes/coding-conventions.md
@@ -114,3 +114,238 @@ uv tool run black YOUR_SCRIPT.py
 # Run the script and uv will manage/install dependencies automatically
 uv run YOUR_SCRIPT.py
 ```
+
+## Coding Style Tips
+
+Treat the following recommendations as soft/loose guidelines that will improve
+the quality of new and refactored code.
+
+### Language Agnostic Tips
+
+#### Function Length
+
+Functions shouldn't be too long. No one likes reading/debugging a 1000+ line
+function that does 20 different things. It can also cause issues for variable
+scoping, compiler optimizations, and debuggers.
+
+A good length for functions is usually < 100 lines, but they can be longer if
+subdividing the function into smaller ones hurts readability.
+
+If your function is long and has separate blocks of tasks, you can extract the
+blocks into their own functions and call them instead.
+
+```cpp
+// Poor
+void run()
+{
+    // Find candidates
+    // ...
+
+    // Process candidates
+    // ...
+
+    // Cleanup
+    // ...
+}
+
+// Better
+void find() {}
+void process() {}
+void cleanup() {}
+
+void run()
+{
+    find();
+    process();
+    cleanup();
+}
+```
+
+#### Guard Clauses/Early Returns
+
+If you have a deeply nested `if` statements, you can reduce nesting by using
+"guard clauses". These work especially well in loops and smaller functions.
+
+```cpp
+// Poor
+void func() {
+    if (a) {
+        if (b) {
+            if (c) {
+                // Do stuff
+            } else {
+                return;
+            }
+        } else {
+            return;
+        }
+    } else {
+        return;
+    }
+}
+
+// Better
+void func() {
+    if (!a) return;
+    if (!b) return;
+    if (!c) return;
+
+    // Do stuff
+}
+```
+
+```cpp
+// Poor
+while (true) {
+    if (a) {
+        if (b) {
+            // Do stuff
+        } else {
+            break;
+        }
+    } else {
+        continue;
+    }
+}
+
+// Better
+while (true) {
+    if (!a) continue;
+    if (!b) break;
+
+    // Do stuff
+}
+```
+
+#### Minimize using magic numbers
+
+"Magic numbers" are hard-coded numeric literals with a special unexplained
+meaning. Some numbers (e.g., 0, 1, 255, 65535) are ok due to being obvious in
+context or easier to understand than a longer variable name. However, when the
+value is more "non-standard" or used in multiple places, understanding and
+modifying the code becomes more difficult and error-prone.
+
+Prefer defining constant variables and using them instead of sprinkling numeric
+literals throughout your code.
+
+```cpp
+enum SCALING_METHOD {
+    NEAREST_NEIGHBOUR = 0,
+    BILINEAR = 1,  // '= 1' is unnecessary as C/C++ automatically increments
+};
+
+constexpr int NEAREST_NEIGHBOUR_SCALING = 0;
+constexpr int BILINEAR_SCALING = 1;
+
+// You can define constants with structs and data structures too.
+constexpr std::array<int, 3> RGB_GREEN = {0, 255, 0};
+```
+
+### C++ Tips
+
+Many concepts here are from the STL. See the [official reference](https://cppreference.com).
+
+#### Memory management
+
+Use smart pointers like `std::unique_ptr` and `std::shared_ptr` instead of raw
+C pointers (e.g. `Foo*`) when modeling ownership. They reduce memory leaks and
+help developers reason about pointer lifetimes.
+
+Prefer using `std::unique_ptr` most of the time as shared ownership (i.e.
+`std::shared_ptr`) is more difficult to reason about. You can return
+`std::unique_ptr` from functions to tell the caller that they need to manage
+the lifetime of the returned pointer. You can also take `std::unique_ptr<T>&&`
+as a function parameter to indicate that the function will take ownership of
+the pointer.
+
+For code that stores a pointer but does not manage the lifetime (i.e. freeing
+the pointer), a simple raw pointer is sufficient. For functions that take raw
+pointers (and don't manage lifetime), a smart pointer can be passed by calling
+the `get()` member function to extract the raw pointer.
+
+This rule is less applicable to GTK code due to the use of `Gtk::managed()`.
+
+#### RAII
+
+C++'s constructors and destructors can be used to simplify and reduce bugs
+related to lifetime management. When an object is constructed, some resource is
+opened. When the object is destroyed, the resource is closed.
+
+Existing examples include smart pointers (e.g. `std::unique_ptr`), file
+handling (e.g. `std::ofstream`), and concurrency
+(`std::lock_guard<std::mutex> lock(mtx)`).
+
+#### Range-based `for` loops
+
+When you want to iterate over a data structure and don't need the index, use
+a range-based `for` loop. This is particularly useful for iterating over arrays
+and lists.
+
+```cpp
+// Good
+for (auto it = vec.begin(); it != vec.end(); it++) {
+    Type& entry = *it;
+    func(entry);
+}
+
+// Better
+for (const auto& entry : vec) {  // Remove const as needed
+    func(entry);
+}
+```
+
+#### Prefer `std::vector` and `std::array` over raw C arrays
+
+Prefer using `std::vector` for dynamically-sized arrays.
+
+Prefer `std::array<T, N> my_array` over `T my_array[N]` for fixed-size
+arrays as it allows C++ utilities like range-based for loops and integration
+with `<algorithm>` header functions.
+
+`std::array` can be passed to functions that need the raw C array by calling
+the `data()` member function.
+
+In most cases, prefer `std::vector` over `std::list` since it is faster due to
+better cache locality.
+
+### `auto` type deduction
+
+`auto` allows the compiler to deduce the type automatically. This may hurt
+readability. It should be used sparingly except for `for` loops, iterators,
+lambdas (and sometimes their arguments), templates, trailing return types, and
+where the deduced type is obvious.
+
+```cpp
+auto ptr = std::make_unique<Foo>();
+auto gtk_box = Gtk::manage(new Box());
+
+std::unordered_map<int> map;
+auto it = map.find(target);
+
+std::vector<int> vec;
+auto start = vec.begin();
+
+for (const auto& it : vec) {}
+
+auto lambda = [](auto arg_type_may_depend_on_lambda_callsite_usage) {};
+```
+
+#### String formatting
+
+Prefer using the more modern [fmt](https://fmt.dev) library for string
+formatting as it is both faster, safer, and more ergonomic. Future C++ versions
+(i.e. C++20 and above) incorporate this library in the STL.
+
+```cpp
+#include <fmt/format.h>
+
+void func()
+{
+    std::string filepath = "foo.jpg";
+    int width = 1920;
+    int height = 1080;
+    std::string text = fmt::format("Image '{}' has dimensions {}x{}",
+                                   filepath, width, height);
+    // Output: Image 'foo.jpg' has dimensions 1920x1080
+}
+```

--- a/devnotes/coding-conventions.md
+++ b/devnotes/coding-conventions.md
@@ -1,0 +1,116 @@
+# Coding Conventions
+
+Try to follow the developer coding conventions. If a file does not follow the
+conventions, try to match existing conventions in the file or local scope.
+Otherwise, stay locally/internally consistent with your own changes.
+
+## C/C++
+
+### Style
+
+- To break header dependencies use forward declarations as much as possible.
+  See [#5197](https://github.com/RawTherapee/RawTherapee/pull/5197#issuecomment-468938190) for some tips.
+- The naming isn't homogeneous throughout the code but here is a rough guideline:
+  - *Identifiers* (variables, functions, methods, keys, enums, etc.) should be clear and unambiguous.
+    - Make them as long as necessary to ensure that your code is understandable to others.
+  - *Types* (classes, structs, enums, typedefs...) should be named with `UpperCamelCase`.
+  - *Functions* and *methods* should be named with `lowerCamelCase`.
+  - *Variables* should be named with `lower_underscores`.
+  - *Enum values*, *constants*, and *macros* should be named with `UPPER_UNDERSCORES`.
+  - Be consistent, even when not sticking to the rules.
+
+### Formatting
+
+#### Old
+
+Some code is formatted using astyle version 3 or newer.
+
+```bash
+astyle --options=rawtherapee.astylerc code.cc
+```
+
+#### New
+
+[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 18
+is used to automatically format files. The files that should be auto-formatted
+can be found in the [.clang-format-ignore](.clang-format-ignore) whitelist.
+
+```bash
+# Run formatting checks
+/path/to/clang-format-18 \
+    --style=file --fallback-style=none \
+    --Werror --ferror-limit=5 \
+    --dry-run FILES...
+
+# Format code in-place
+/path/to/clang-format-18 \
+    --style=file --fallback-style=none \
+    --Werror --ferror-limit=0 \
+    -i FILES...
+
+# Format all using find
+find . -type f \( -name "*.h" -o -name "*.hh" -o -name "*.hpp" -o -name "*.c" -o -name "*.cc" -o -name "*.cpp" \) | \
+    xargs /path/to/clang-format-18 \
+    --style=file --fallback-style=none --Werror --ferror-limit=0 -i
+
+# Format all using [fd](https://github.com/sharkdp/fd)
+fd -e h -e hh -e hpp -e c -e cc -e cpp -X \
+    /path/to/clang-format-18 \
+    --style=file --fallback-style=none --Werror --ferror-limit=0 -i
+```
+
+If your version of clang-format is not 18, you will need to use a package
+manager with the specific version or
+[download the binary](https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.8)
+from official LLVM releases. Download the appropriate `clang+llvm` tarball and
+use the provided standalone `bin/clang-format` executable in it. The 18.1.8
+release has prebuilt binaries for Linux, Windows, and MacOS (ARM). If all else
+fails, you can build clang 18 from source.
+
+The prebuilt clang-format 18.1.8 executable from the LLVM repo may require you
+to install `ncurses5` if you get an error about `libtinfo.so.5`.
+
+### Tips for clang-format
+
+Disable format for a block of code using `// clang-format off/on`
+
+```cpp
+// clang-format off
+keep_formatting_for_this_code();
+// clang-format on
+```
+
+Keep each element of an initializer list on different lines by adding a
+trailing comma.
+
+```cpp
+// If no trailing comma is present, clang-format tends to bin-pack the elements
+// when they exceed the line length limit.
+std::array bin_packed_array = { 0, 1,
+                                2 };
+
+std::array desired_format_array = {
+    0,
+    1,
+    2,  // Trailing comma
+};
+```
+
+## Python
+
+- Follow PEP 8 [naming conventions](https://peps.python.org/pep-0008/#naming-conventions)
+- Format by running [black](https://github.com/psf/black) with default settings
+
+An easy way of running black is to use [uv](https://docs.astral.sh/uv/). It
+also lets you create one-off scripts with extra dependencies.
+
+```bash
+# Create a one-off script that has dependencies managed by uv
+uv init --script YOUR_SCRIPT.py
+# Add dependencies to the script
+uv add --script YOUR_SCRIPT.py numpy onnx
+# Format your code
+uv tool run black YOUR_SCRIPT.py
+# Run the script and uv will manage/install dependencies automatically
+uv run YOUR_SCRIPT.py
+```


### PR DESCRIPTION
- Updates `.clang-format` rules for clang-format 18
  - AppImage Ubuntu 24.04 has tool bundled
  - First version with prebuilt binary for Windows
  - Prebuilt binaries  for Linux and MacOS (ARM) available
- Add `devnotes/coding_conventions.md`

View the sample [formatted repo](https://github.com/digitalcarp/RawTherapee/tree/clang-format-test).

Closes #6125.