### PR TITLE
Enable C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 project(RawTherapee)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -29,11 +29,15 @@ include(cmake/StandardProjectSettings.cmake)
 rt_force_out_of_source_builds()
 rt_basic_build_settings()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
-                                            VERSION_LESS "4.9")
-    message(
-        FATAL_ERROR
-            "Building RawTherapee requires using GCC version 4.9 or higher!")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10")
+    message(FATAL_ERROR "Building RawTherapee requires using AppleClang 10 or higher!")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8")
+    message(FATAL_ERROR "Building RawTherapee requires using Clang 8 or higher!")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.1")
+    message(FATAL_ERROR "Building RawTherapee requires using GCC version 8.1 or higher!")
 endif()
 
 # Warning for GCC vectorization issues, which causes problems #5749 and #6384:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The most useful feedback is based on the latest development code, and in the cas
 - Work in a new branch. Fork if necessary.
 - Keep branches small so that completed and working features can be merged into the "dev" branch often, and so that they can be abandoned if they head in the wrong direction.
 - Documentation for your work must be provided in order for your branch to be merged if it changes or adds anything the user should know about. The documentation can be provided in plain-text or markdown form as a comment in the issue or pull request.
-- Use C++11.
+- Use C++17 (see [allowed features](devnotes/cpp.md))
 - To break header dependencies use forward declarations as much as possible. See [#5197](https://github.com/RawTherapee/RawTherapee/pull/5197#issuecomment-468938190) for some tips.
 - The naming isn't homogeneous throughout the code but here is a rough guideline:
   - *Identifiers* (variables, functions, methods, keys, enums, etc.) should be clear and unambiguous. Make them as long as necessary to ensure that your code is understandable to others.

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -37,13 +37,13 @@ New since 5.13:
 
 In general:
 - To get the source code, either clone from git or use the tarball from https://rawtherapee.com/shared/source/. Do not use the auto-generated GitHub release tarballs.
+- RawTherapee requires GCC 8.1, Clang 8, or Apple Clang 10 (or newer).
 - Requires GTK+ version >= 3.24.3.
 - GTK+ versions 3.24.3 - 3.24.6 have an issue where combobox menu scroll-arrows are missing when the combobox list does not fit vertically on the screen. As a result, users would not be able to scroll in the following comboboxes: Processing Profiles, Film Simulation, and the camera and lens profiles in Profiled Lens Correction.
 - JPEG XL read support depends on libjxl. By default, RawTherapee builds with JPEG XL support if and only if libjxl is present. Use -DWITH_JXL="ON" or DWITH_JXL="OFF" to explicitly enable or disable, respectively, JPEG XL support.
 - RawTherapee builds with a custom version of LibRaw by default. To use the system LibRaw, use -DWITH_SYSTEM_LIBRAW="ON". Requires LibRaw >= 0.21.
 - To avoid Rust dependencies, build using the LunaSVG rendering backend with -DSVG_BACKEND="lunasvg". Use -DWITH_SYSTEM_LUNASVG="ON" to use the system LunaSVG.
 - RawTherapee has hand-optimized code for most x86_64 architectures. SIMDe is an optional compile-time dependency that allows most of the optimizations to be used on arm64. Enable it with -DWITH_SIMDE="ON".
-- RawTherapee 5 requires GCC-4.9 or higher, or Clang.
 - Do not use -ffast-math, it will not make RawTherapee faster but will introduce artifacts.
 - Use -O3, it will make RawTherapee faster with no known side-effects.
 - For stable releases use -DCACHE_NAME_SUFFIX=""

--- a/cmake/Compile.cmake
+++ b/cmake/Compile.cmake
@@ -9,7 +9,7 @@ include(FindX87Math)
 # This comment is specifically about add_custom_target(UpdateInfo ...)
 function(rt_setup_target CXX_TARGET)
     # Set globally in project CMakeLists.txt
-    # target_compile_features(${CXX_TARGET} PUBLIC cxx_std_11)
+    # target_compile_features(${CXX_TARGET} PUBLIC cxx_std_17)
     # set_target_properties(
     #     ${CXX_TARGET} PROPERTIES
     #     CXX_STANDARD_REQUIRED ON

--- a/devnotes/cpp.md
+++ b/devnotes/cpp.md
@@ -1,0 +1,24 @@
+# C++
+
+We are currently using C++17 ([cppreference](https://en.cppreference.com/w/cpp/compiler_support/17)).
+
+All core language features are allowed, but only a subset of library features
+should be used due to lack of support on older compilers.
+
+## Library Features to Avoid
+
+- Parallel algorithms and execution policies ([P0024R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0024r2.html))
+- [P0220R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0220r1.html)
+  - [Polymorphic memory resources](https://en.cppreference.com/w/cpp/header/memory_resource.html)
+  - [`std::apply`](https://en.cppreference.com/w/cpp/utility/apply.html)
+  - [Searchers](https://en.cppreference.com/w/cpp/functional.html#Searchers)
+  - [`std::sample`](https://en.cppreference.com/w/cpp/algorithm/sample.html)
+- [Mathematical special functions](https://en.cppreference.com/w/cpp/numeric/special_math.html) ([P0226R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0226r1.pdf))
+- [`constexpr std::addressof`](https://en.cppreference.com/w/cpp/memory/addressof.html) ([LWG2296](https://cplusplus.github.io/LWG/issue2296))
+- [P0067R5](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0067r5.html)
+  - [`std::to_chars`](https://en.cppreference.com/w/cpp/utility/to_chars.html)
+  - [`std::from_chars`](https://en.cppreference.com/w/cpp/utility/from_chars.html)
+- `std::shared_ptr` and `std::weak_ptr` with array support ([P0414R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0414r2.html))
+- `std::shared_ptr<T[]>` ([P0497R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0497r0.html))
+- [Hardware interference size](https://en.cppreference.com/w/cpp/thread/hardware_destructive_interference_size.html) ([P0154R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0154r1.html))
+- [`std::hash<std::filesystem::path>`](https://en.cppreference.com/w/cpp/filesystem/path/hash.html) ([LWG3657](https://cplusplus.github.io/LWG/issue3657))

--- a/rtengine/curves.h
+++ b/rtengine/curves.h
@@ -39,8 +39,6 @@ class ustring;
 
 }
 
-using namespace std;
-
 namespace rtengine
 {
 

--- a/rtengine/params/serdes.cc
+++ b/rtengine/params/serdes.cc
@@ -50,7 +50,7 @@ Glib::ustring expandRelativePath2(const Glib::ustring &procparams_fname, const G
 #if defined (_WIN32)
     // if this is Windows, replace any "/" in the filename with "\\"
     size_t pos = embedded_fname.find("/");
-    while (pos != string::npos) {
+    while (pos != Glib::ustring::npos) {
         embedded_fname.replace(pos, 1, "\\");
         pos = embedded_fname.find("/", pos);
     }
@@ -58,7 +58,7 @@ Glib::ustring expandRelativePath2(const Glib::ustring &procparams_fname, const G
 #if !defined (_WIN32)
     // if this is not Windows, replace any "\\" in the filename with "/"
     size_t pos = embedded_fname.find("\\");
-    while (pos != string::npos) {
+    while (pos != Glib::ustring::npos) {
         embedded_fname.replace(pos, 1, "/");
         pos = embedded_fname.find("\\", pos);
     }

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -116,7 +116,7 @@ void transLineFuji(const float* const red, const float* const green, const float
     int start = std::abs(fw - i);
     int w = fw * 2 + 1;
     int h = (imheight - fw) * 2 + 1;
-    int end = min(h + fw - i, w - fw + i);
+    int end = std::min(h + fw - i, w - fw + i);
 
     switch (tran & TR_ROT) {
         case TR_R180:


### PR DESCRIPTION
- Update compile to use C++17
- Decent LTS OS support with default packages
  - Debian buster/bookworm
  - Ubuntu LTS 20.04
  - MacOS 12
- Explicit list of library features to avoid due to above OS restrictions

Closes #5238