### PR TITLE
Improve scroll wheel handling in preferences

### DIFF
--- a/rtgui/guiutils.cc
+++ b/rtgui/guiutils.cc
@@ -1140,6 +1140,26 @@ void MyComboBoxText::get_preferred_width_for_height_vfunc (int height, int &mini
     minimum_width = rtengine::max(minimumWidth, RTScalable::scalePixelSize(10));
 }
 
+void MyComboBoxText::setPreferredWidthFromEntries()
+{
+    Glib::RefPtr<Gtk::TreeModel> model = get_model();
+    if (!model) {
+        return;
+    }
+    Glib::RefPtr<Pango::Layout> layout = create_pango_layout("");
+    layout->set_font_description(get_pango_context()->get_font_description());
+    int max_width = 0;
+    for (const Gtk::TreeModel::Row& row : model->children()) {
+        Glib::ustring text;
+        row.get_value(0, text);
+        layout->set_text(text);
+        int w, h;
+        layout->get_pixel_size(w, h);
+        max_width = std::max(max_width, w);
+    }
+    setPreferredWidth(max_width + 42, max_width + 42);
+}
+
 
 MyComboBox::MyComboBox ()
 {
@@ -1282,6 +1302,40 @@ bool MyHScale::on_key_press_event (GdkEventKey* event)
     } else {
         return Gtk::Widget::on_key_press_event(event);
     }
+}
+
+MyTreeView::MyTreeView ()
+{
+}
+
+bool MyTreeView::on_scroll_event (GdkEventScroll* event)
+{
+    // If widget has focus, propagate the signal to the wrapper.
+    if (event->state & GDK_SHIFT_MASK || has_focus()) {
+        Gtk::TreeView::on_scroll_event(event);
+        return false;
+    }
+
+    // Not focused: find outer ScrolledWindow (skip immediate parent which wraps this TreeView)
+    Gtk::ScrolledWindow* outer_sw = nullptr;
+    int scroll_window_count = 0;
+    for (Gtk::Widget* p = get_parent(); p; p = p->get_parent()) {
+        if (auto* sw = dynamic_cast<Gtk::ScrolledWindow*>(p)) {
+            scroll_window_count++;
+            // Skip the first ScrolledWindow (immediate parent), find the outer one
+            if (scroll_window_count > 1) {
+                outer_sw = sw;
+                break;
+            }
+        }
+    }
+    // Forward scroll to outer scroller (dialog/page)
+    if (outer_sw) {
+        return outer_sw->event(reinterpret_cast<GdkEvent*>(event));
+    }
+
+    // No outer scroller found, just propagate
+    return false;
 }
 
 class MyFileChooserWidget::Impl

--- a/rtgui/guiutils.h
+++ b/rtgui/guiutils.h
@@ -405,6 +405,7 @@ public:
     explicit MyComboBoxText (bool has_entry = false);
 
     void setPreferredWidth (int minimum_width, int natural_width);
+    void setPreferredWidthFromEntries();
     void connect(const sigc::connection &connection) { myConnection = connection; }
     void block(bool blocked) { myConnection.block(blocked); }
 };
@@ -434,6 +435,19 @@ protected:
     bool on_scroll_event (GdkEventScroll* event) override;
     bool on_key_press_event (GdkEventKey* event) override;
 
+};
+
+/**
+ * @brief subclass of Gtk::TreeView in order to handle the scrollwheel
+ */
+class MyTreeView final : public Gtk::TreeView
+{
+
+protected:
+    bool on_scroll_event (GdkEventScroll* event) override;
+
+public:
+    MyTreeView ();
 };
 
 class MyFileChooserWidget

--- a/rtgui/windows/preferences.cc
+++ b/rtgui/windows/preferences.cc
@@ -49,7 +49,7 @@ void placeSpinBox(Gtk::Container* where, Gtk::SpinButton* &spin, const std::stri
         HB->set_tooltip_text (M (toolTip));
     }
     Gtk::Label* label = Gtk::manage ( new Gtk::Label (M (labelText) + ":", Gtk::ALIGN_START));
-    spin = Gtk::manage ( new Gtk::SpinButton () );
+    spin = Gtk::manage ( new MySpinButton() );
     spin->set_digits (digits);
     spin->set_increments (inc0, inc1);
     spin->set_max_length (maxLength); // Will this be sufficient? :)
@@ -614,7 +614,7 @@ Gtk::Widget* Preferences::getImageProcessingPanel ()
     txtCustProfBuilderPath->set_tooltip_markup(M("PREFERENCES_CUSTPROFBUILDHINT"));
     txtCustProfBuilderPath->set_hexpand();
     Gtk::Label* cpltypelab = Gtk::manage(new Gtk::Label(M("PREFERENCES_CUSTPROFBUILDKEYFORMAT") + ":", Gtk::ALIGN_START));
-    custProfBuilderLabelType = Gtk::manage(new Gtk::ComboBoxText());
+    custProfBuilderLabelType = Gtk::manage(new MyComboBoxText());
     custProfBuilderLabelType->append(M("PREFERENCES_CUSTPROFBUILDKEYFORMAT_TID"));
     custProfBuilderLabelType->append(M("PREFERENCES_CUSTPROFBUILDKEYFORMAT_NAME"));
     custProfBuilderLabelType->append(M("PREFERENCES_CUSTPROFBUILDKEYFORMAT_TID") + "_" + M("PREFERENCES_CUSTPROFBUILDKEYFORMAT_NAME"));
@@ -629,15 +629,17 @@ Gtk::Widget* Preferences::getImageProcessingPanel ()
 
     Gtk::Frame* fdp = Gtk::manage(new Gtk::Frame(M("PREFERENCES_PROFILEHANDLING")));
     Gtk::Grid* vbdp = Gtk::manage(new Gtk::Grid());
-    saveParamsPreference = Gtk::manage(new Gtk::ComboBoxText());
+    saveParamsPreference = Gtk::manage(new MyComboBoxText());
     saveParamsPreference->append(M("PREFERENCES_PROFILESAVEINPUT"));
     saveParamsPreference->append(M("PREFERENCES_PROFILESAVECACHE"));
     saveParamsPreference->append(M("PREFERENCES_PROFILESAVEBOTH"));
+    setExpandAlignProperties(saveParamsPreference, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
     Gtk::Label *splab = Gtk::manage (new Gtk::Label (M ("PREFERENCES_PROFILESAVELOCATION") + ":", Gtk::ALIGN_START));
     Gtk::Label* lplab = Gtk::manage (new Gtk::Label (M ("PREFERENCES_PROFILELOADPR") + ":", Gtk::ALIGN_START));
-    loadParamsPreference = Gtk::manage(new Gtk::ComboBoxText());
+    loadParamsPreference = Gtk::manage(new MyComboBoxText());
     loadParamsPreference->append(M("PREFERENCES_PROFILEPRCACHE"));
     loadParamsPreference->append(M("PREFERENCES_PROFILEPRFILE"));
+    setExpandAlignProperties(loadParamsPreference, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
     vbdp->set_row_spacing(2);
     vbdp->attach(*splab, 0, 0, 1, 1);
     vbdp->attach(*saveParamsPreference, 1, 0, 1, 1);
@@ -651,7 +653,7 @@ Gtk::Widget* Preferences::getImageProcessingPanel ()
     Gtk::Grid *mtbl = Gtk::manage(new Gtk::Grid());
     setExpandAlignProperties(mtbl, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
 
-    metadataSyncCombo = Gtk::manage(new Gtk::ComboBoxText());
+    metadataSyncCombo = Gtk::manage(new MyComboBoxText());
     metadataSyncCombo->set_active(0);
     metadataSyncCombo->append(M("PREFERENCES_METADATA_SYNC_NONE"));
     metadataSyncCombo->append(M("PREFERENCES_METADATA_SYNC_READ"));
@@ -662,7 +664,7 @@ Gtk::Widget* Preferences::getImageProcessingPanel ()
     setExpandAlignProperties(mlbl, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
     setExpandAlignProperties(metadataSyncCombo, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
 
-    xmpSidecarCombo = Gtk::manage(new Gtk::ComboBoxText());
+    xmpSidecarCombo = Gtk::manage(new MyComboBoxText());
     xmpSidecarCombo->set_active(0);
     xmpSidecarCombo->append(M("PREFERENCES_XMP_SIDECAR_MODE_STD"));
     xmpSidecarCombo->append(M("PREFERENCES_XMP_SIDECAR_MODE_EXT"));
@@ -763,10 +765,11 @@ Gtk::Widget* Preferences::getImageProcessingPanel ()
     cropFrame->set_label_align (0.025, 0.5);
     Gtk::Grid *cropGrid = Gtk::manage(new Gtk::Grid());
     Gtk::Label *cropGuidesLbl = Gtk::manage(new Gtk::Label(M("PREFERENCES_CROP_GUIDES") + ": ", Gtk::ALIGN_START));
-    cropGuidesCombo = Gtk::manage(new Gtk::ComboBoxText());
+    cropGuidesCombo = Gtk::manage(new MyComboBoxText());
     cropGuidesCombo->append(M("PREFERENCES_CROP_GUIDES_NONE"));
     cropGuidesCombo->append(M("PREFERENCES_CROP_GUIDES_FRAME"));
     cropGuidesCombo->append(M("PREFERENCES_CROP_GUIDES_FULL"));
+    cropGuidesCombo->setPreferredWidthFromEntries();
     cropAutoFitCB = Gtk::manage(new Gtk::CheckButton());
     Gtk::Label *cropAutoFitLbl = Gtk::manage(new Gtk::Label(M("PREFERENCES_CROP_AUTO_FIT"), Gtk::ALIGN_START));
     cropAutoFitLbl->set_line_wrap(true);
@@ -795,13 +798,14 @@ Gtk::Widget* Preferences::getImageProcessingPanel ()
       label->set_line_wrap(true);
       grid->attach(*label, 0, 0);
 
-      maxZoomCombo = Gtk::manage(new Gtk::ComboBoxText());
+      maxZoomCombo = Gtk::manage(new MyComboBoxText());
 
       // Labels order matches to Options::MaxZoom enum
       for (int i = 1; i <= 8; ++i) {
         maxZoomCombo->append(Glib::ustring::compose("%100%%", i));
       }
       maxZoomCombo->append("1600%");
+      maxZoomCombo->setPreferredWidthFromEntries();
 
       grid->attach(*maxZoomCombo, 1, 0, 1, 1);
       frame->add(*grid);
@@ -825,7 +829,7 @@ Gtk::Widget* Preferences::getPerformancePanel()
     Gtk::Box* hbprevdemo = Gtk::manage(new Gtk::Box());
     hbprevdemo->set_spacing(4);
     Gtk::Label* lprevdemo = Gtk::manage (new Gtk::Label (M("PREFERENCES_PREVDEMO_LABEL"), Gtk::ALIGN_START));
-    cprevdemo = Gtk::manage(new Gtk::ComboBoxText());
+    cprevdemo = Gtk::manage(new MyComboBoxText());
     cprevdemo->append(M("PREFERENCES_PREVDEMO_FAST"));
     cprevdemo->append(M("PREFERENCES_PREVDEMO_SIDECAR"));
     cprevdemo->set_active(1);
@@ -878,7 +882,7 @@ Gtk::Widget* Preferences::getPerformancePanel()
     placeSpinBox(inspectorvb, maxInspectorBuffersSB, "PREFERENCES_INSPECT_MAXBUFFERS_LABEL", 0, 1, 5, 2, 1, 12, "PREFERENCES_INSPECT_MAXBUFFERS_TOOLTIP");
 
     Gtk::Box* insphb = Gtk::manage(new Gtk::Box());
-    thumbnailInspectorMode = Gtk::manage(new Gtk::ComboBoxText());
+    thumbnailInspectorMode = Gtk::manage(new MyComboBoxText());
     thumbnailInspectorMode->append(M("PREFERENCES_THUMBNAIL_INSPECTOR_JPEG"));
     thumbnailInspectorMode->append(M("PREFERENCES_THUMBNAIL_INSPECTOR_RAW"));
     thumbnailInspectorMode->append(M("PREFERENCES_THUMBNAIL_INSPECTOR_RAW_IF_NO_JPEG_FULLSIZE"));
@@ -944,12 +948,12 @@ Gtk::Widget* Preferences::getColorManPanel ()
     Gtk::Grid* gmonitor = Gtk::manage(new Gtk::Grid());
     gmonitor->set_column_spacing(4);
 
-    monProfile = Gtk::manage(new Gtk::ComboBoxText());
+    monProfile = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(monProfile, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
     Gtk::Label* mplabel = Gtk::manage(new Gtk::Label(M("PREFERENCES_MONPROFILE") + ":", Gtk::ALIGN_START));
     setExpandAlignProperties(mplabel, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
-    monIntent = Gtk::manage(new Gtk::ComboBoxText());
+    monIntent = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(monIntent, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
     Gtk::Label* milabel = Gtk::manage(new Gtk::Label(M("PREFERENCES_MONINTENT") + ":", Gtk::ALIGN_START));
     setExpandAlignProperties(milabel, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
@@ -1008,12 +1012,12 @@ Gtk::Widget* Preferences::getColorManPanel ()
     Gtk::Frame* fprinter = Gtk::manage(new Gtk::Frame(M("PREFERENCES_PRINTER")));
     Gtk::Grid* gprinter = Gtk::manage(new Gtk::Grid());
     gprinter->set_column_spacing(4);
-    prtProfile = Gtk::manage(new Gtk::ComboBoxText());
+    prtProfile = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(prtProfile, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
     Gtk::Label* pplabel = Gtk::manage(new Gtk::Label(M("PREFERENCES_PRTPROFILE") + ":"));
     setExpandAlignProperties(pplabel, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
-    prtIntent = Gtk::manage(new Gtk::ComboBoxText());
+    prtIntent = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(prtIntent, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
     Gtk::Label* pilabel = Gtk::manage(new Gtk::Label(M("PREFERENCES_PRTINTENT") + ":"));
     setExpandAlignProperties(pilabel, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
@@ -1127,7 +1131,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
 
     Gtk::Label* curveBBoxPosL = Gtk::manage(new Gtk::Label(M("PREFERENCES_CURVEBBOXPOS") + ":"));
     setExpandAlignProperties(curveBBoxPosL, false, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
-    curveBBoxPosC = Gtk::manage(new Gtk::ComboBoxText());
+    curveBBoxPosC = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(curveBBoxPosC, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_BASELINE);
     curveBBoxPosC->append(M("PREFERENCES_CURVEBBOXPOS_ABOVE"));
     curveBBoxPosC->append(M("PREFERENCES_CURVEBBOXPOS_RIGHT"));
@@ -1140,12 +1144,12 @@ Gtk::Widget* Preferences::getGeneralPanel()
     workflowGrid->attach_next_to(*curveBBoxPosC, *editorLayout, Gtk::POS_BOTTOM, 1, 1);
     workflowGrid->attach_next_to(*curveBBoxPosRestartL, *lNextStart, Gtk::POS_BOTTOM, 1, 1);
 
-    curveBBoxPosS = Gtk::manage(new Gtk::ComboBoxText());
+    curveBBoxPosS = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(curveBBoxPosS, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_BASELINE);
 
     Gtk::Label* complexityL = Gtk::manage(new Gtk::Label(M("PREFERENCES_COMPLEXITYLOC") + ":"));
     setExpandAlignProperties(complexityL, false, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
-    complexitylocal = Gtk::manage(new Gtk::ComboBoxText());
+    complexitylocal = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(complexitylocal, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_BASELINE);
     complexitylocal->append(M("PREFERENCES_COMPLEXITY_EXP"));
     complexitylocal->append(M("PREFERENCES_COMPLEXITY_NORM"));
@@ -1157,7 +1161,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
 
     Gtk::Label* spotlocalL = Gtk::manage(new Gtk::Label(M("PREFERENCES_SPOTLOC") + ":"));
     setExpandAlignProperties(spotlocalL, false, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
-    spotlocal = Gtk::manage(new Gtk::ComboBoxText());
+    spotlocal = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(spotlocal, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_BASELINE);
     spotlocal->append(M("TP_LOCALLAB_EXNORM"));
     spotlocal->append(M("TP_LOCALLAB_EXECLU"));
@@ -1232,7 +1236,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
 
     Gtk::Label* langlab = Gtk::manage(new Gtk::Label(M("PREFERENCES_SELECTLANG") + ":"));
     setExpandAlignProperties(langlab, false, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
-    languages = Gtk::manage(new Gtk::ComboBoxText());
+    languages = Gtk::manage(new MyComboBoxText());
     setExpandAlignProperties(languages, false, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
 
     std::vector<Glib::ustring> langs;
@@ -1248,6 +1252,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
             languages->append(lang, display_name);
         }
     }
+    languages->setPreferredWidthFromEntries();
 
     Gtk::Label* langw = Gtk::manage(new Gtk::Label(Glib::ustring(" (") + M("PREFERENCES_APPLNEXTSTARTUP") + ")"));
     setExpandAlignProperties(langw, false, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
@@ -1271,7 +1276,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
     Gtk::Label* themeRestartLbl = Gtk::manage ( new Gtk::Label (Glib::ustring (" (") + M ("PREFERENCES_APPLNEXTSTARTUP") + ")") );
     setExpandAlignProperties(themeRestartLbl, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
-    themeCBT = Gtk::manage(new Gtk::ComboBoxText());
+    themeCBT = Gtk::manage(new MyComboBoxText());
     themeCBT->set_active(0);
     parseThemeDir(Glib::build_filename(App::get().argv0(), "themes"));
     for (size_t i = 0; i < themeNames.size(); i++) {
@@ -1343,7 +1348,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
 
     Gtk::Label* hll = Gtk::manage(new Gtk::Label(M("PREFERENCES_HLTHRESHOLD") + ": "));
     setExpandAlignProperties(hll, true, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
-    hlThresh = Gtk::manage(new Gtk::SpinButton());
+    hlThresh = Gtk::manage(new MySpinButton());
     setExpandAlignProperties(hlThresh, false, false, Gtk::ALIGN_END, Gtk::ALIGN_BASELINE);
     hlThresh->set_digits(0);
     hlThresh->set_increments(1, 10);
@@ -1353,7 +1358,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
 
     Gtk::Label* shl = Gtk::manage(new Gtk::Label(M("PREFERENCES_SHTHRESHOLD") + ": "));
     setExpandAlignProperties(shl, true, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
-    shThresh = Gtk::manage(new Gtk::SpinButton());
+    shThresh = Gtk::manage(new MySpinButton());
     setExpandAlignProperties(shThresh, false, false, Gtk::ALIGN_END, Gtk::ALIGN_BASELINE);
     shThresh->show();
     shThresh->set_digits(0);
@@ -1376,7 +1381,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
 
     Gtk::Label* panFactorLabel = Gtk::manage(new Gtk::Label(M("PREFERENCES_PANFACTORLABEL") + ":", Gtk::ALIGN_START));
     setExpandAlignProperties(panFactorLabel, false, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
-    panFactor = Gtk::manage(new Gtk::SpinButton());
+    panFactor = Gtk::manage(new MySpinButton());
     setExpandAlignProperties(panFactor, true, false, Gtk::ALIGN_START, Gtk::ALIGN_BASELINE);
     panFactor->set_digits(0);
     panFactor->set_increments(1, 5);
@@ -1523,7 +1528,7 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
 
     Gtk::Box* hbrecent = Gtk::manage(new Gtk::Box());
     Gtk::Label* labrecent = Gtk::manage (new Gtk::Label (M("PREFERENCES_MAXRECENTFOLDERS") + ":", Gtk::ALIGN_START));
-    maxRecentFolders = Gtk::manage(new Gtk::SpinButton());
+    maxRecentFolders = Gtk::manage(new MySpinButton());
     hbrecent->pack_start(*labrecent, Gtk::PACK_SHRINK, 4);
     hbrecent->pack_start(*maxRecentFolders, Gtk::PACK_SHRINK, 4);
     maxRecentFolders->set_digits(0);
@@ -1534,12 +1539,12 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
     // Recursive browsing options.
     Gtk::Box *hbBrowseRecursive = Gtk::manage(new Gtk::Box());
     Gtk::Label *labBrowseRecursiveDepth = Gtk::manage(new Gtk::Label(M("PREFERENCES_BROWSERECURSIVEDEPTH") + ":"));
-    browseRecursiveDepth = Gtk::manage(new Gtk::SpinButton());
+    browseRecursiveDepth = Gtk::manage(new MySpinButton());
     browseRecursiveDepth->set_digits(0);
     browseRecursiveDepth->set_increments(1, 5);
     browseRecursiveDepth->set_range(1, 999);
     Gtk::Label *labBrowseRecursiveMaxDirs = Gtk::manage(new Gtk::Label(M("PREFERENCES_BROWSERECURSIVEMAXDIRS") + ":"));
-    browseRecursiveMaxDirs = Gtk::manage(new Gtk::SpinButton());
+    browseRecursiveMaxDirs = Gtk::manage(new MySpinButton());
     browseRecursiveMaxDirs->set_digits(0);
     browseRecursiveMaxDirs->set_increments(1, 5);
     browseRecursiveMaxDirs->set_range(1, 999);
@@ -1614,7 +1619,7 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
     hb0->pack_end(*delExt, Gtk::PACK_SHRINK, 4);
     hb0->pack_end(*addExt, Gtk::PACK_SHRINK, 4);
 
-    extensions = Gtk::manage(new Gtk::TreeView());
+    extensions = Gtk::manage(new MyTreeView());
     Gtk::ScrolledWindow* hscrollw = Gtk::manage(new Gtk::ScrolledWindow());
     hscrollw->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS);
     hscrollw->add(*extensions);
@@ -1641,14 +1646,14 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
 
     Gtk::Label* maxThumbHeightLbl = Gtk::manage (new Gtk::Label(M("PREFERENCES_CACHETHUMBHEIGHT") + ":"));
     setExpandAlignProperties(maxThumbHeightLbl, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-    maxThumbHeightSB = Gtk::manage (new Gtk::SpinButton());
+    maxThumbHeightSB = Gtk::manage (new MySpinButton());
     maxThumbHeightSB->set_digits (0);
     maxThumbHeightSB->set_increments (1, 10);
     maxThumbHeightSB->set_range (40, 800);
 
     Gtk::Label* maxCacheEntriesLbl = Gtk::manage (new Gtk::Label(M("PREFERENCES_CACHEMAXENTRIES") + ":"));
     setExpandAlignProperties(maxCacheEntriesLbl, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-    maxCacheEntriesSB = Gtk::manage (new Gtk::SpinButton());
+    maxCacheEntriesSB = Gtk::manage (new MySpinButton());
     maxCacheEntriesSB->set_digits (0);
     maxCacheEntriesSB->set_increments (1, 10);
     maxCacheEntriesSB->set_range (10, 100000);
@@ -1761,7 +1766,7 @@ Gtk::Widget* Preferences::getSoundsPanel ()
     Gtk::Label* lSndLngEditProcDoneSecs = Gtk::manage (new Gtk::Label (M("PREFERENCES_SND_THRESHOLDSECS") + Glib::ustring (":"), Gtk::ALIGN_START));
     pSndLngEditProcDone->pack_start(*lSndLngEditProcDoneSecs, Gtk::PACK_SHRINK, 12);
 
-    spbSndLngEditProcDoneSecs = Gtk::manage(new Gtk::SpinButton());
+    spbSndLngEditProcDoneSecs = Gtk::manage(new MySpinButton());
     spbSndLngEditProcDoneSecs->set_digits(1);
     spbSndLngEditProcDoneSecs->set_increments(0.5, 1);
     spbSndLngEditProcDoneSecs->set_range(0, 10);

--- a/rtgui/windows/preferences.h
+++ b/rtgui/windows/preferences.h
@@ -80,7 +80,7 @@ class Preferences final :
     Gtk::TreeIter currRawRow; // :)
     ProfileStoreComboBox* iprofiles;
     Gtk::TreeIter currImgRow;
-    Gtk::ComboBoxText* languages;
+    MyComboBoxText* languages;
     Gtk::CheckButton* ckbLangAutoDetect;
     Gtk::Entry* dateformat;
     MyFileChooserEntry* startupdir;
@@ -117,11 +117,11 @@ class Preferences final :
     Gtk::CheckButton* showExpComp;
 
     MyFileChooserButton* iccDir;
-    Gtk::ComboBoxText* prtProfile;
-    Gtk::ComboBoxText* prtIntent;
+    MyComboBoxText* prtProfile;
+    MyComboBoxText* prtIntent;
     Gtk::CheckButton* prtBPC;
-    Gtk::ComboBoxText* monProfile;
-    Gtk::ComboBoxText* monIntent;
+    MyComboBoxText* monProfile;
+    MyComboBoxText* monIntent;
     Gtk::CheckButton* mcie;
     Gtk::CheckButton* monBPC;
     Gtk::CheckButton* cbAutoMonProfile;
@@ -147,30 +147,30 @@ class Preferences final :
 //   Gtk::ComboBoxText* view;
 //    Gtk::ComboBoxText* grey;
 //    Gtk::ComboBoxText* greySc;
-    Gtk::ComboBoxText* dnv;
-    Gtk::ComboBoxText* dnti;
-    Gtk::ComboBoxText* dnaut;
-    Gtk::ComboBoxText* dnautsimpl;
-    Gtk::ComboBoxText* dnwavlev;
-    Gtk::ComboBoxText* dnliss;
+    MyComboBoxText* dnv;
+    MyComboBoxText* dnti;
+    MyComboBoxText* dnaut;
+    MyComboBoxText* dnautsimpl;
+    MyComboBoxText* dnwavlev;
+    MyComboBoxText* dnliss;
 
     Gtk::Frame* waveletFrame;
     Gtk::Box* waveletTileSizeHBox;
     Gtk::Label* waveletTileSizeLabel;
-    Gtk::ComboBoxText* waveletTileSizeCombo;
+    MyComboBoxText* waveletTileSizeCombo;
 
-    Gtk::ComboBoxText* cprevdemo;
+    MyComboBoxText* cprevdemo;
     Gtk::CheckButton* ctiffserialize;
-    Gtk::ComboBoxText* curveBBoxPosC;
-    Gtk::ComboBoxText* curveBBoxPosS;
+    MyComboBoxText* curveBBoxPosC;
+    MyComboBoxText* curveBBoxPosS;
 
-    Gtk::ComboBoxText* complexitylocal;
-    Gtk::ComboBoxText* spotlocal;
+    MyComboBoxText* complexitylocal;
+    MyComboBoxText* spotlocal;
 
     Gtk::CheckButton* inspectorWindowCB;
     Gtk::CheckButton* zoomOnScrollCB;
 
-    Gtk::ComboBoxText* themeCBT;
+    MyComboBoxText* themeCBT;
     Gtk::FontButton* mainFontFB;
     Gtk::FontButton* colorPickerFontFB;
     Gtk::ColorButton* cropMaskColorCB;
@@ -180,7 +180,7 @@ class Preferences final :
     Gtk::SpinButton*   maxThumbHeightSB;
     Gtk::SpinButton*   maxCacheEntriesSB;
     Gtk::Entry*     extension;
-    Gtk::TreeView*  extensions;
+    MyTreeView*     extensions;
     Gtk::Button*    addExt;
     Gtk::Button*    delExt;
     Gtk::Button*    moveExtUp;
@@ -201,7 +201,7 @@ class Preferences final :
     Gtk::SpinButton*  chunkSizeRGBSB;
     Gtk::SpinButton*  chunkSizeXTSB;
     Gtk::SpinButton*  maxInspectorBuffersSB;
-    Gtk::ComboBoxText *thumbnailInspectorMode;
+    MyComboBoxText* thumbnailInspectorMode;
 
     Gtk::CheckButton* ckbmenuGroupRank;
     Gtk::CheckButton* ckbmenuGroupLabel;
@@ -213,10 +213,10 @@ class Preferences final :
     Gtk::Button*      behSetAll;
     Gtk::CheckButton* chOverwriteOutputFile;
 
-    Gtk::ComboBoxText* saveParamsPreference;
+    MyComboBoxText* saveParamsPreference;
     Gtk::CheckButton* useBundledProfiles;
-    Gtk::ComboBoxText* loadParamsPreference;
-    Gtk::ComboBoxText* editorLayout;
+    MyComboBoxText* loadParamsPreference;
+    MyComboBoxText* editorLayout;
     RTWindow* parent;
 
     Gtk::CheckButton* ckbSndEnable;
@@ -229,7 +229,7 @@ class Preferences final :
     Gtk::CheckButton *thumbnailRankColorMode;
 
     Gtk::Entry* txtCustProfBuilderPath;
-    Gtk::ComboBoxText* custProfBuilderLabelType;
+    MyComboBoxText* custProfBuilderLabelType;
 
     Gtk::CheckButton* ckbHistogramPositionLeft;
     Gtk::CheckButton* ckbFileBrowserToolbarSingleRow;
@@ -242,15 +242,15 @@ class Preferences final :
 
     DynamicProfilePanel *dynProfilePanel;
 
-    Gtk::ComboBoxText *cropGuidesCombo;
+    MyComboBoxText* cropGuidesCombo;
     Gtk::CheckButton *cropAutoFitCB;
 
     Gtk::CheckButton *enableLibRaw;
 
-    Gtk::ComboBoxText *maxZoomCombo;
+    MyComboBoxText* maxZoomCombo;
 
-    Gtk::ComboBoxText *metadataSyncCombo;
-    Gtk::ComboBoxText *xmpSidecarCombo;
+    MyComboBoxText* metadataSyncCombo;
+    MyComboBoxText* xmpSidecarCombo;
 
     Glib::ustring storedValueRaw;
     Glib::ustring storedValueImg;


### PR DESCRIPTION
## Summary

This PR improves scroll wheel behavior in the Preferences dialog by preventing unfocused widgets from capturing scroll events. Key improvements include:

- Scroll wheel events now propagate to the outer preferences window when scrolling over unfocused ComboBoxTexts, SpinButtons, and TreeViews
- Users can now scroll the preferences page naturally without widgets hijacking the scroll events
- Focused widgets continue to respond to scroll events as expected (e.g., changing ComboBoxText values or SpinButton numbers)
- Special handling for nested ScrolledWindows to ensure proper event propagation

## Motivation

The previous implementation had a frustrating UX issue: when scrolling through the Preferences dialog, any unfocused widget under the mouse cursor would capture scroll events, preventing the page from scrolling. Users had to carefully position their mouse to avoid these widgets, making navigation through preferences cumbersome. This presented the user with two problems.

1 - Some Preferences remained hidden from view, since scrolling to them required intent.
2 - It was easy to accidentally modify preferences while attempting to scroll through them.

This PR is tangentially related to PR #7599, which adds a full-width TreeView to the Preferences dialog that makes scrolling challenging. That said, since that PR is not yet merged a slight modification would have to be made to that PR to adjust to the proposed scrolling behavior of this PR.

## Changes

### Technical Implementation

The main strategy is to replace all instances of ComboBoxText, SpinButton, and TreeView with MyComboBoxText, MySpinButton, and MyTreeView. Both MyComboBoxText and MySpinButton are already defined in guiutils.h and used extensively in the software but somewhat ignored in the preferences, and their definition already implements improved scrolling behavior where values only change when the shift key is pressed or when the widget has focus. 

The transition from Gtk::SpinButton to MySpinButton was smooth, but using MyComboBoxText presented problems since its default width is fixed at 70px and doesn't adapt to entry content (which standard ComboBoxText does and is the expected behavior of a couple of inputs in the preferences). This was fixed by introducing `setPreferredWidthFromEntries()`, which calculates the width of all entries and adjusts the combobox width to fit the longest entry.

MyTreeView had to be implemented from scratch. Its implementation is more complex than the others because each TreeView is wrapped in a ScrolledWindow that continues scrolling even when the TreeView ignores scroll events. To achieve the expected behavior, scroll events must be manually propagated to the second-level parent.

As an addendum, I kept the name MyTreeView to remain consistent with the naming scheme in guiutils.h, though RTTreeView might be more appropriate.

**Files Modified:**
- `rtgui/guiutils.h` (+14 lines) - Added MyTreeView class declaration and setPreferredWidthFromEntries() method
- `rtgui/guiutils.cc` (+54 lines) - Implemented MyTreeView scroll handling and width calculation
- `rtgui/windows/preferences.h` (+28 lines, -28 lines) - Changed widget types from Gtk to custom My* classes
- `rtgui/windows/preferences.cc` (+65 lines, -58 lines) - Replaced all Gtk::ComboBoxText, Gtk::SpinButton, and Gtk::TreeView instances with custom classes

## Testing Performed

- Verified scroll wheel scrolls the preferences page when mouse is over unfocused widgets
- Verified TreeView (file extensions list) scrolls internally when focused, propagates when unfocused
- Confirmed Shift+Scroll continues to work as expected
- Tested across multiple preference tabs and widget types

## User Experience

**Before:**
- Scrolling over any ComboBox/SpinButton/TreeView would capture the scroll event
- Users had to carefully avoid widgets while scrolling the preferences
- Frustrating navigation experience

**After:**
- Natural scrolling behavior throughout the preferences dialog
- Widgets only capture scroll when focused (intentional interaction)
- Smooth, predictable scrolling experience

## Compatibility

Fully backward compatible:
- No changes to data structures or file formats
- No changes to user-visible behavior except improved scroll handling
- Existing configurations continue to work unchanged
