### PR TITLE
Filesystem events

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2074,7 +2074,7 @@ PREFERENCES_BROWSERECURSIVEDEPTH;Browse sub-folders depth
 PREFERENCES_BROWSERECURSIVEFOLLOWLINKS;Follow symbolic links when browsing sub-folders
 PREFERENCES_BROWSERECURSIVEMAXDIRS;Maximum sub-folders
 PREFERENCES_BROWSERTIMEOUT;File Browser directory monitor delay time
-PREFERENCES_BROWSERTIMEOUTHINT;The minimum time in seconds how long newly found files need to be idle before added to the File Browser.\nSetting this value to 0 will disable all File Browser directory monitoring. You will need to refresh to see new or saved files or externally deleted files to disappear from the File Browser.\nDirectories and attached drives will still be monitored for the Places view and the Folders tree.
+PREFERENCES_BROWSERTIMEOUTHINT;The minimum time in seconds how long newly found files must to be idle before being added to the File Browser.\nSetting this value to 0 will disable all File Browser directory monitoring. You will need to refresh to see new or saved files or externally deleted files to disappear from the File Browser.\nDirectories and attached drives will still be monitored for the Places view and the Folders tree.
 PREFERENCES_CACHECLEAR;Clear
 PREFERENCES_CACHECLEAR_ALL;Clear all cached files:
 PREFERENCES_CACHECLEAR_ALLBUTPROFILES;Clear all cached files except for cached processing profiles:

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2073,6 +2073,8 @@ PREFERENCES_BEHSETALLHINT;Set all parameters to the <b>Set</b> mode.\nAdjustment
 PREFERENCES_BROWSERECURSIVEDEPTH;Browse sub-folders depth
 PREFERENCES_BROWSERECURSIVEFOLLOWLINKS;Follow symbolic links when browsing sub-folders
 PREFERENCES_BROWSERECURSIVEMAXDIRS;Maximum sub-folders
+PREFERENCES_BROWSERTIMEOUT;File Browser directory monitor delay time
+PREFERENCES_BROWSERTIMEOUTHINT;The minimum time in seconds how long newly found files need to be idle before added to the File Browser.\nSetting this value to 0 will disable all File Browser directory monitoring. You will need to refresh to see new or saved files or externally deleted files to disappear from the File Browser.\nDirectories and attached drives will still be monitored for the Places view and the Folders tree.
 PREFERENCES_CACHECLEAR;Clear
 PREFERENCES_CACHECLEAR_ALL;Clear all cached files:
 PREFERENCES_CACHECLEAR_ALLBUTPROFILES;Clear all cached files except for cached processing profiles:

--- a/rtgui/cachemanager.cc
+++ b/rtgui/cachemanager.cc
@@ -178,11 +178,26 @@ void CacheManager::deleteEntry (const Glib::ustring& fname)
     }
 }
 
-void CacheManager::clearFromCache (const Glib::ustring& fname, const Glib::ustring& md5, bool purge) const
+void CacheManager::clearFromCache (const Glib::ustring& fname, bool purge) const
 {
     MyMutex::MyLock lock (mutex);
 
-    deleteFiles (fname, md5, true, purge);
+    auto iterator = openEntries.find (fname);
+
+    if (iterator != openEntries.end ()) {
+        deleteFiles (fname, iterator->second->getMD5(), true, true);
+        return;
+    }
+
+    const auto md5 = getMD5 (fname);
+    if (!md5.empty()) {
+        deleteFiles (fname, md5, true, purge);
+        return;
+    }
+
+    if (rtengine::settings->verbose) {
+        std::cerr << "clearFromCache failed because MD5 couldn't be resolved for " << fname << std::endl;
+    }
 }
 
 void CacheManager::renameEntry (const std::string& oldfilename, const std::string& oldmd5, const std::string& newfilename)

--- a/rtgui/cachemanager.h
+++ b/rtgui/cachemanager.h
@@ -60,7 +60,7 @@ public:
     void clearAll () const;
     void clearImages () const;
     void clearProfiles () const;
-    void clearFromCache (const Glib::ustring& fname, const Glib::ustring& md5, bool purge) const;
+    void clearFromCache (const Glib::ustring& fname, bool purge) const;
     static std::string getMD5 (const Glib::ustring& fname);
 
     Glib::ustring    getCacheFileName (const Glib::ustring& subDir,

--- a/rtgui/dirbrowser.cc
+++ b/rtgui/dirbrowser.cc
@@ -128,6 +128,10 @@ DirBrowser::DirBrowser () : dirTreeModel(),
 DirBrowser::~DirBrowser()
 {
     idle_register.destroy();
+
+#ifdef _WIN32
+    timerEventSource.disconnect();
+#endif
 }
 
 void DirBrowser::fillDirTree ()
@@ -196,35 +200,12 @@ void DirBrowser::addRoot (char letter)
     child->set_value (dtColumns.filename, Glib::ustring("foo"));
 }
 
-void DirBrowser::updateDirTreeRoot ()
+bool DirBrowser::updateVolumes ()
 {
-
-    for (Gtk::TreeModel::iterator i = dirTreeModel->children().begin(); i != dirTreeModel->children().end(); ++i) {
-        updateDirTree (i);
-    }
-}
-
-void DirBrowser::updateDirTree (const Gtk::TreeModel::iterator& iter)
-{
-
-    if (dirtree->row_expanded (dirTreeModel->get_path (iter))) {
-        updateDir (iter);
-
-        for (Gtk::TreeModel::iterator i = iter->children().begin(); i != iter->children().end(); ++i) {
-            updateDirTree (i);
-        }
-    }
-}
-
-void DirBrowser::updateVolumes ()
-{
-
     unsigned int nvolumes = GetLogicalDrives ();
 
     if (nvolumes != volumes) {
-        GThreadLock lock;
-
-        for (int i = 0; i < 32; i++)
+        for (int i = 0; i < 32; i++) {
             if (((volumes >> i) & 1) && !((nvolumes >> i) & 1)) { // volume i has been deleted
                 for (Gtk::TreeModel::iterator iter = dirTreeModel->children().begin(); iter != dirTreeModel->children().end(); ++iter)
                     if (iter->get_value (dtColumns.filename).c_str()[0] - 'A' == i) {
@@ -234,15 +215,11 @@ void DirBrowser::updateVolumes ()
             } else if (!((volumes >> i) & 1) && ((nvolumes >> i) & 1)) {
                 addRoot ('A' + i);    // volume i has been added
             }
-
+        }
         volumes = nvolumes;
     }
-}
 
-int updateVolumesUI (void* br)
-{
-    (static_cast<DirBrowser*>(br))->updateVolumes ();
-    return 1;
+    return true;
 }
 
 #endif
@@ -253,13 +230,13 @@ void DirBrowser::fillRoot ()
 #ifdef _WIN32
     volumes = GetLogicalDrives ();
 
-    for (int i = 0; i < 32; i++)
+    for (int i = 0; i < 32; i++) {
         if ((volumes >> i) & 1) {
             addRoot ('A' + i);
         }
+    }
 
-    // since sigc++ is not thread safe, we have to use the glib function
-    g_timeout_add (5000, updateVolumesUI, this);
+    timerEventSource = Glib::signal_timeout().connect(sigc::mem_fun(*this, &DirBrowser::updateVolumes), 5000);
 #else
     Gtk::TreeModel::Row rootRow = *(dirTreeModel->append());
     rootRow[dtColumns.filename] = "/";
@@ -277,7 +254,6 @@ void DirBrowser::on_sort_column_changed() const
 
 void DirBrowser::row_expanded (const Gtk::TreeModel::iterator& iter, const Gtk::TreeModel::Path& path)
 {
-
     expandSuccess = false;
 
     // We will disable model's sorting because it decreases speed of inserting new items
@@ -325,9 +301,9 @@ void DirBrowser::row_expanded (const Gtk::TreeModel::iterator& iter, const Gtk::
         iter->set_value(dtColumns.icon_name, openfolder);
     }
 
-    Glib::RefPtr<Gio::FileMonitor> monitor = dir->monitor_directory(Gio::FileMonitorFlags::FILE_MONITOR_WATCH_MOVES);
-    iter->set_value (dtColumns.monitor, monitor);
-    monitor->signal_changed().connect (sigc::bind(sigc::mem_fun(*this, &DirBrowser::file_changed), iter, dir->get_parse_name()));
+    Glib::RefPtr<Gio::FileMonitor> monitor = dir->monitor_directory();
+    iter->set_value(dtColumns.monitor, monitor);
+    monitor->signal_changed().connect(sigc::bind(sigc::mem_fun(*this, &DirBrowser::file_changed), iter));
 }
 
 void DirBrowser::row_collapsed (const Gtk::TreeModel::iterator& iter, const Gtk::TreeModel::Path& path)
@@ -340,8 +316,7 @@ void DirBrowser::row_collapsed (const Gtk::TreeModel::iterator& iter, const Gtk:
 
 void DirBrowser::updateDir (const Gtk::TreeModel::iterator& iter)
 {
-
-    // first test if some files are deleted
+    // first test if directories have been deleted
     bool change = true;
 
     while (change) {
@@ -350,14 +325,13 @@ void DirBrowser::updateDir (const Gtk::TreeModel::iterator& iter)
         for (Gtk::TreeModel::iterator it = iter->children().begin(); it != iter->children().end(); ++it)
             if (!Glib::file_test (it->get_value (dtColumns.dirname), Glib::FILE_TEST_EXISTS)
                     || !Glib::file_test (it->get_value (dtColumns.dirname), Glib::FILE_TEST_IS_DIR)) {
-                GThreadLock lock;
                 dirTreeModel->erase (it);
                 change = true;
                 break;
             }
     }
 
-    // test if new files are created
+    // test if new directories have been created
     auto dir = Gio::File::create_for_path (iter->get_value (dtColumns.dirname));
     auto subDirs = listSubDirs (dir, App::get().options().fbShowHidden);
 
@@ -369,7 +343,6 @@ void DirBrowser::updateDir (const Gtk::TreeModel::iterator& iter)
         }
 
         if (!found) {
-            GThreadLock lock;
             addDir (iter, subDirs[i]);
         }
     }
@@ -389,7 +362,6 @@ void DirBrowser::addDir (const Gtk::TreeModel::iterator& iter, const Glib::ustri
 
 void DirBrowser::row_activated (const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn* column)
 {
-
     Glib::ustring dname = dirTreeModel->get_iter (path)->get_value (dtColumns.dirname);
 
     if (Glib::file_test (dname, Glib::FILE_TEST_IS_DIR)) {
@@ -467,7 +439,6 @@ Gtk::TreePath DirBrowser::expandToDir (const Glib::ustring& absDirPath)
 
 void DirBrowser::open (const Glib::ustring& dirname, const Glib::ustring& fileName)
 {
-
     dirtree->collapse_all ();
 
     // WARNING & TODO: One should test here if the directory/file has R/W access permission to avoid crash
@@ -491,34 +462,59 @@ void DirBrowser::open (const Glib::ustring& dirname, const Glib::ustring& fileNa
     dirSelectionSignal (absDirPath, absFilePath);
 }
 
-void DirBrowser::file_changed (const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type, const Gtk::TreeModel::iterator& iter, const Glib::ustring& dirName)
+void DirBrowser::eventDirectoryDeleted(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File> directory)
 {
-    // file is the file that is/was in the monitored directory. other_file is
-    // null if only one file is involved (create/delete events), the file that
-    // is/was in another directory, or the new name for a renamed file. We want
-    // to inspect the file type of the changed file, so we decide which file to
-    // use based on the event type.
-    const Glib::RefPtr<Gio::File> current_file =
-        (event_type == Gio::FILE_MONITOR_EVENT_MOVED ||
-            event_type == Gio::FILE_MONITOR_EVENT_RENAMED ||
-            event_type == Gio::FILE_MONITOR_EVENT_MOVED_OUT)
-            ? other_file
-            : file;
+    if (!directory) {
+        return;
+    }
 
-    // No need to update the directory if the even type is not rename, move,
-    // create, or delete, or if the file is not a directory.
-    if (!current_file ||
-        event_type == Gio::FILE_MONITOR_EVENT_CHANGED ||
+    for (Gtk::TreeModel::iterator it = iter->children().begin(); it != iter->children().end(); ++it) {
+        if (it->get_value (dtColumns.dirname) == directory->get_path()) {
+            dirTreeModel->erase (it);
+            break;
+        }
+    }
+}
+
+void DirBrowser::eventDirectoryCreated(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File> directory)
+{
+    if (!directory) {
+        return;
+    }
+
+    if ( std::find_if(iter->children().begin(), iter->children().end(),
+                    [&directory, this](const Gtk::TreeModel::iterator it) { return it->get_value(dtColumns.dirname) == directory->get_path(); })
+                    != iter->children().end()) {
+        return;
+    }
+
+    addDir(iter, directory->get_basename());
+    // sub directories are needed only if the entry is expanded, they are handled by the row_expanded call
+}
+
+void DirBrowser::file_changed (const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type, const Gtk::TreeModel::iterator& iter)
+{
+    if (event_type == Gio::FILE_MONITOR_EVENT_CHANGED ||
         event_type == Gio::FILE_MONITOR_EVENT_CHANGES_DONE_HINT ||
         event_type == Gio::FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED ||
         event_type == Gio::FILE_MONITOR_EVENT_PRE_UNMOUNT ||
         (event_type != Gio::FILE_MONITOR_EVENT_DELETED &&
             event_type != Gio::FILE_MONITOR_EVENT_UNMOUNTED &&
-            !Glib::file_test(current_file->get_path(), Glib::FILE_TEST_IS_DIR))) {
+            !Glib::file_test(file->get_path(), Glib::FILE_TEST_IS_DIR))) {
         return;
     }
 
-    updateDir (iter);
+    switch (event_type) {
+        case Gio::FILE_MONITOR_EVENT_DELETED:
+            // there is no way to know if the event was triggered by a file or a directory, this will be called for both
+            eventDirectoryDeleted(iter, file);
+            break;
+        case Gio::FILE_MONITOR_EVENT_CREATED:
+            eventDirectoryCreated(iter, file);
+            break;
+        default:
+            updateDir (iter);
+    }
 }
 
 void DirBrowser::selectDir (Glib::ustring dir)

--- a/rtgui/dirbrowser.cc
+++ b/rtgui/dirbrowser.cc
@@ -236,6 +236,7 @@ void DirBrowser::fillRoot ()
         }
     }
 
+    // Keep updating the volumes on 5 second interval
     timerEventSource = Glib::signal_timeout().connect(sigc::mem_fun(*this, &DirBrowser::updateVolumes), 5000);
 #else
     Gtk::TreeModel::Row rootRow = *(dirTreeModel->append());
@@ -462,7 +463,7 @@ void DirBrowser::open (const Glib::ustring& dirname, const Glib::ustring& fileNa
     dirSelectionSignal (absDirPath, absFilePath);
 }
 
-void DirBrowser::eventDirectoryDeleted(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File> directory)
+void DirBrowser::eventDirectoryDeleted(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File>& directory)
 {
     if (!directory) {
         return;
@@ -476,7 +477,7 @@ void DirBrowser::eventDirectoryDeleted(const Gtk::TreeModel::iterator& iter, con
     }
 }
 
-void DirBrowser::eventDirectoryCreated(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File> directory)
+void DirBrowser::eventDirectoryCreated(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File>& directory)
 {
     if (!directory) {
         return;

--- a/rtgui/dirbrowser.h
+++ b/rtgui/dirbrowser.h
@@ -72,17 +72,16 @@ private:
 #ifdef _WIN32
     unsigned int volumes;
     sigc::connection timerEventSource;
-public:
+
     bool updateVolumes ();
-private:
     void addRoot (char letter);
 #endif
     void addDir (const Gtk::TreeModel::iterator& iter, const Glib::ustring& dirname);
     Gtk::TreePath expandToDir (const Glib::ustring& dirName);
     void updateDir (const Gtk::TreeModel::iterator& iter);
 
-    void eventDirectoryDeleted(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File> directory);
-    void eventDirectoryCreated(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File> directory);
+    void eventDirectoryDeleted(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File>& directory);
+    void eventDirectoryCreated(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File>& directory);
 
     IdleRegister idle_register;
 

--- a/rtgui/dirbrowser.h
+++ b/rtgui/dirbrowser.h
@@ -71,16 +71,18 @@ private:
 
 #ifdef _WIN32
     unsigned int volumes;
+    sigc::connection timerEventSource;
 public:
-    void updateVolumes ();
-    void updateDirTree  (const Gtk::TreeModel::iterator& iter);
-    void updateDirTreeRoot  ();
+    bool updateVolumes ();
 private:
     void addRoot (char letter);
 #endif
     void addDir (const Gtk::TreeModel::iterator& iter, const Glib::ustring& dirname);
     Gtk::TreePath expandToDir (const Glib::ustring& dirName);
     void updateDir (const Gtk::TreeModel::iterator& iter);
+
+    void eventDirectoryDeleted(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File> directory);
+    void eventDirectoryCreated(const Gtk::TreeModel::iterator& iter, const Glib::RefPtr<Gio::File> directory);
 
     IdleRegister idle_register;
 
@@ -93,7 +95,7 @@ public:
     void row_expanded   (const Gtk::TreeModel::iterator& iter, const Gtk::TreeModel::Path& path);
     void row_collapsed  (const Gtk::TreeModel::iterator& iter, const Gtk::TreeModel::Path& path);
     void row_activated  (const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn* column);
-    void file_changed   (const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type, const Gtk::TreeModel::iterator& iter, const Glib::ustring& dirName);
+    void file_changed   (const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type, const Gtk::TreeModel::iterator& iter);
     void open           (const Glib::ustring& dirName, const Glib::ustring& fileName = ""); // goes to dir "dirName" and selects file "fileName"
     void selectDir      (Glib::ustring dir);
 

--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -130,7 +130,7 @@ protected:
     BatchPParamsChangeListener* bppcl;
     FileBrowserListener* tbl;
     BrowserFilter filter;
-    int numFiltered;
+    std::size_t numFiltered;
 
     void toTrashRequested   (std::vector<FileBrowserEntry*> tbe);
     void fromTrashRequested (std::vector<FileBrowserEntry*> tbe);
@@ -172,7 +172,7 @@ public:
     void applyPartialMenuItemActivated (ProfileStoreLabel *label);
 
     void applyFilter (const BrowserFilter& filter);
-    int getNumFiltered()
+    std::size_t getNumFiltered()
     {
         return numFiltered;
     }

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -572,10 +572,6 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
         hScrollPos[i] = 0;
         vScrollPos[i] = 0;
     }
-
-    if (App::get().options().newFileDelayTime > 0) {
-        timerEventSource = Glib::signal_timeout().connect(sigc::mem_fun(*this, &FileCatalog::timerEvents), 1000);
-    }
 }
 
 FileCatalog::~FileCatalog()
@@ -668,6 +664,8 @@ void FileCatalog::closeDir ()
     // terminate thumbnail updater
     thumbImageUpdater->removeAllJobs ();
 
+    timerEventSource.disconnect();
+
     // remove entries
     selectedDirectory = "";
     fileBrowser->close ();
@@ -698,8 +696,10 @@ std::vector<Glib::ustring> FileCatalog::getFileList(Glib::ustring root, int star
     std::vector<Glib::ustring> names;
 
     const auto& options = App::get().options();
-    int dirs_left = options.browseRecursiveMaxDirs - start_depth;
-    getFilesRecursively(root, options.browseRecursiveDepth, dirs_left, names, dirs_explored);
+    int dirs_left = options.browseRecursiveMaxDirs - dirMonitors.size();
+    if (dirs_left > 0) {
+        getFilesRecursively(root, options.browseRecursiveDepth, dirs_left, names, dirs_explored);
+    }
 
     return names;
 }
@@ -744,6 +744,9 @@ void FileCatalog::dirSelected (const Glib::ustring& dirname, const Glib::ustring
         }
 
         if (App::get().options().newFileDelayTime > 0) {
+            if (!timerEventSource.connected()) {
+                timerEventSource = Glib::signal_timeout().connect(sigc::mem_fun(*this, &FileCatalog::timerEvents), 1000);
+            }
             refreshDirectoryMonitors(allDirs);
         }
     } catch (Glib::Exception& ex) {
@@ -869,6 +872,7 @@ void FileCatalog::previewFailed(int dir_id, Glib::ustring file, FailReason reaso
             fileNameList.erase(std::remove(fileNameList.begin(), fileNameList.end(), file), fileNameList.end());
             previewsToLoad--;
 
+            _refreshProgressBar();
             return false;
         },
         G_PRIORITY_DEFAULT_IDLE
@@ -1420,6 +1424,9 @@ void FileCatalog::renameRequested(const std::vector<FileBrowserEntry*>& tbe)
                     if (::g_rename (ofname.c_str (), nfname.c_str ()) == 0) {
                         cacheMgr->renameEntry (ofname, tbe[i]->thumbnail->getMD5(), nfname);
                         ::g_remove((ofname + App::PARAM_FILE_EXTENSION).c_str ());
+                        if (!timerEventSource.connected()) {
+                            delete fileBrowser->delEntry(ofname);
+                        }
                         // skip ahead and just add the file to bypass directory monitoring timeout
                         addFile(nfname);
                     }
@@ -1891,7 +1898,7 @@ bool FileCatalog::restoreResetState ()
 }
 
 bool FileCatalog::eventDeletedFile(const Glib::RefPtr<Gio::File>& file)
-{ 
+{
     auto pos = std::find(fileNameList.cbegin(), fileNameList.cend(), file->get_path());
     if (pos != fileNameList.cend()) {
         cacheMgr->clearFromCache(file->get_path(), true);
@@ -1918,7 +1925,7 @@ void FileCatalog::eventDeletedDirectory(const Glib::RefPtr<Gio::File>& directory
     const std::vector<ThumbBrowserEntryBase*>& t = fileBrowser->getEntries();
     for (const auto& entry : t) {
         // trying to match with files from the directory and its subdirectories based on path
-        if ( entry->filename.rfind(directory->get_path()) == 0 ) {
+        if (entry->filename == directory->get_path() || entry->filename.rfind(directory->get_path() + G_DIR_SEPARATOR, 0) == 0) {
             filesToDel.push_back(entry->filename);
         }
     }
@@ -1937,7 +1944,14 @@ void FileCatalog::eventDeletedDirectory(const Glib::RefPtr<Gio::File>& directory
     // if the directory is being cut out, the subfolders will not get their own events
     // deleting all monitors that start with a matching path
     dirMonitors.erase(std::remove_if(dirMonitors.begin(), dirMonitors.end(),
-                    [&directory](const FileMonitorInfo &fileMonitorInfo) { return (fileMonitorInfo.filePath.rfind(directory->get_path(), 0) == 0); })
+                    [&directory](const FileMonitorInfo &fileMonitorInfo)
+                    { 
+                        if (fileMonitorInfo.filePath == directory->get_path()) {
+                            return true;
+                        } else {
+                            return (fileMonitorInfo.filePath.rfind(directory->get_path() + G_DIR_SEPARATOR, 0) == 0);
+                        }
+                    })
                     , dirMonitors.end());
 
     if (refresh) {
@@ -1996,8 +2010,8 @@ void FileCatalog::eventChangesDoneDirectory(const Glib::RefPtr<Gio::File>& direc
         oldNames.insert(oldName.collate_key());
     }
 
-    std::vector<Glib::RefPtr<Gio::File>> allDirs;
-    std::vector<Glib::ustring> fileList = getFileList(directory->get_path(), recursiondepth, &allDirs);
+    std::vector<Glib::RefPtr<Gio::File>> newDirs;
+    std::vector<Glib::ustring> fileList = getFileList(directory->get_path(), recursiondepth, &newDirs);
     for (const auto& newName : fileList) {
         if (oldNames.find(newName.collate_key()) == oldNames.end()) {
             addToPendingFiles(newName);
@@ -2005,7 +2019,9 @@ void FileCatalog::eventChangesDoneDirectory(const Glib::RefPtr<Gio::File>& direc
     }
     _refreshProgressBar();
 
-    refreshDirectoryMonitors(allDirs, true);
+    if (!newDirs.empty()) {
+        refreshDirectoryMonitors(newDirs, true);
+    }
 }
 
 void FileCatalog::eventChangesDoneFile(const Glib::RefPtr<Gio::File>& file)
@@ -2072,7 +2088,7 @@ void FileCatalog::on_dir_changed (const Glib::RefPtr<Gio::File>& file, const Gli
             }  
             break;
         case Gio::FILE_MONITOR_EVENT_DELETED:
-            if ( !eventDeletedFile(file) ) {
+            if (!eventDeletedFile(file)) {
                 // There is no way to test, that I know of, if the passed file parameter refers to a file or a directory.
                 // So the logic is: if the eventDeletedFile fails, it is a directory.
                 // this will cause overhead, when events for already handled files come but to resolve it completely may need some reorganization of data

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -696,9 +696,9 @@ std::vector<Glib::ustring> FileCatalog::getFileList(Glib::ustring root, int star
     std::vector<Glib::ustring> names;
 
     const auto& options = App::get().options();
-    int dirs_left = options.browseRecursiveMaxDirs - dirMonitors.size();
-    if (dirs_left > 0) {
-        getFilesRecursively(root, options.browseRecursiveDepth, dirs_left, names, dirs_explored);
+    int dirs_left = options.browseRecursiveMaxDirs - static_cast<int>(dirMonitors.size());
+    if (dirs_left >= 0) {
+        getFilesRecursively(root, options.browseRecursiveDepth - start_depth, dirs_left, names, dirs_explored);
     }
 
     return names;
@@ -2019,9 +2019,7 @@ void FileCatalog::eventChangesDoneDirectory(const Glib::RefPtr<Gio::File>& direc
     }
     _refreshProgressBar();
 
-    if (!newDirs.empty()) {
-        refreshDirectoryMonitors(newDirs, true);
-    }
+    refreshDirectoryMonitors(newDirs, true);
 }
 
 void FileCatalog::eventChangesDoneFile(const Glib::RefPtr<Gio::File>& file)

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -50,6 +50,23 @@ using namespace std;
 
 namespace {
 
+int GetRecursionDepth(const Glib::ustring base, const Glib::RefPtr<Gio::File>& directory)
+{
+    if (!directory || base == directory->get_path()) {
+        return 0;
+    }
+
+    int depth = 1;
+
+    Glib::RefPtr<Gio::File> parent = directory->get_parent();
+    while (parent && base != parent->get_path()) {
+        depth++;
+        parent = parent->get_parent();
+    }
+
+    return depth;
+}
+
 void getFilesRecursively(
     const Glib::ustring &dir_path,
     int max_depth,
@@ -143,7 +160,6 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
     filterPanel(nullptr),
     exportPanel(nullptr),
     previewsToLoad(0),
-    previewsLoaded(0),
     modifierKey(0),
     coarsePanel(cp),
     toolBar(tb)
@@ -187,7 +203,7 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
     buttonBrowsePath->set_image (*iRefreshWhite);
     buttonBrowsePath->set_tooltip_markup (M("FILEBROWSER_BROWSEPATHBUTTONHINT"));
     buttonBrowsePath->set_relief (Gtk::RELIEF_NONE);
-    buttonBrowsePath->signal_clicked().connect( sigc::mem_fun(*this, &FileCatalog::buttonBrowsePathPressed) );
+    buttonBrowsePath->signal_clicked().connect (sigc::mem_fun(*this, &FileCatalog::buttonBrowsePathPressed));
     hbBrowsePath->pack_start (*BrowsePath, Gtk::PACK_EXPAND_WIDGET, 0);
     hbBrowsePath->pack_start (*buttonBrowsePath, Gtk::PACK_SHRINK, 0);
     hbToolBar1->pack_start (*hbBrowsePath, Gtk::PACK_EXPAND_WIDGET, 0);
@@ -556,11 +572,17 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
         hScrollPos[i] = 0;
         vScrollPos[i] = 0;
     }
+
+    if (App::get().options().newFileDelayTime > 0) {
+        timerEventSource = Glib::signal_timeout().connect(sigc::mem_fun(*this, &FileCatalog::timerEvents), 1000);
+    }
 }
 
 FileCatalog::~FileCatalog()
 {
     idle_register.destroy();
+
+    timerEventSource.disconnect();
 
     for (int i = 0; i < 5; i++) {
         delete iranked[i];
@@ -650,6 +672,7 @@ void FileCatalog::closeDir ()
     selectedDirectory = "";
     fileBrowser->close ();
     fileNameList.clear ();
+    pendingFiles.clear ();
 
     {
         MyMutex::MyLock lock(dirEFSMutex);
@@ -670,6 +693,17 @@ std::vector<Glib::ustring> FileCatalog::getFileList(std::vector<Glib::RefPtr<Gio
     return names;
 }
 
+std::vector<Glib::ustring> FileCatalog::getFileList(Glib::ustring root, int start_depth, std::vector<Glib::RefPtr<Gio::File>> *dirs_explored)
+{
+    std::vector<Glib::ustring> names;
+
+    const auto& options = App::get().options();
+    int dirs_left = options.browseRecursiveMaxDirs - start_depth;
+    getFilesRecursively(root, options.browseRecursiveDepth, dirs_left, names, dirs_explored);
+
+    return names;
+}
+
 void FileCatalog::dirSelected (const Glib::ustring& dirname, const Glib::ustring& openfile)
 {
 
@@ -682,7 +716,6 @@ void FileCatalog::dirSelected (const Glib::ustring& dirname, const Glib::ustring
 
         closeDir();
         previewsToLoad = 0;
-        previewsLoaded = 0;
 
         // if openfile exists, we have to open it first (it is a command line argument)
         if (!openfile.empty()) {
@@ -694,11 +727,11 @@ void FileCatalog::dirSelected (const Glib::ustring& dirname, const Glib::ustring
         std::vector<Glib::RefPtr<Gio::File>> allDirs;
         BrowsePath->set_text(selectedDirectory);
         buttonBrowsePath->set_image(*iRefreshWhite);
-        fileNameList = getFileList(&allDirs);
+        std::vector<Glib::ustring> fileList = getFileList(&allDirs);
 
-        for (unsigned int i = 0; i < fileNameList.size(); i++) {
-            if (openfile.empty() || fileNameList[i] != openfile) { // if we opened a file at the beginning don't add it again
-                addFile(fileNameList[i]);
+        for (unsigned int i = 0; i < fileList.size(); i++) {
+            if (openfile.empty() || fileList[i] != openfile) { // if we opened a file at the beginning don't add it again
+                addFile(fileList[i]);
             }
         }
 
@@ -710,27 +743,32 @@ void FileCatalog::dirSelected (const Glib::ustring& dirname, const Glib::ustring
             filepanel->loadingThumbs(M("PROGRESSBAR_LOADINGTHUMBS"), 0);
         }
 
-        refreshDirectoryMonitors(allDirs);
+        if (App::get().options().newFileDelayTime > 0) {
+            refreshDirectoryMonitors(allDirs);
+        }
     } catch (Glib::Exception& ex) {
         std::cout << ex.what();
     }
 }
 
-void FileCatalog::refreshDirectoryMonitors(const std::vector<Glib::RefPtr<Gio::File>> &dirs_to_monitor)
+void FileCatalog::refreshDirectoryMonitors(const std::vector<Glib::RefPtr<Gio::File>> &dirs_to_monitor, bool compound_update)
 {
-    std::vector<Glib::ustring> updated_dir_names;
-    std::transform(
-        dirs_to_monitor.cbegin(), dirs_to_monitor.cend(),
-        std::back_inserter(updated_dir_names),
-        [](const Glib::RefPtr<Gio::File> &updated_dir) { return updated_dir->get_path(); });
+    if (!compound_update) {
+        // Remove monitors on directories that are no longer shown.
 
-    // Remove monitors on directories that are no longer shown.
-    dirMonitors.erase(
-        std::remove_if(dirMonitors.begin(), dirMonitors.end(),
-            [&updated_dir_names](const FileMonitorInfo &fileMonitorInfo) {
-                return std::find(updated_dir_names.cbegin(), updated_dir_names.cend(), fileMonitorInfo.filePath) == updated_dir_names.cend();
-            }),
-        dirMonitors.end());
+        std::vector<Glib::ustring> updated_dir_names;
+        std::transform(
+            dirs_to_monitor.cbegin(), dirs_to_monitor.cend(),
+            std::back_inserter(updated_dir_names),
+            [](const Glib::RefPtr<Gio::File> &updated_dir) { return updated_dir->get_path(); });
+        
+        dirMonitors.erase(
+            std::remove_if(dirMonitors.begin(), dirMonitors.end(),
+                [&updated_dir_names](const FileMonitorInfo &fileMonitorInfo) {
+                    return std::find(updated_dir_names.cbegin(), updated_dir_names.cend(), fileMonitorInfo.filePath) == updated_dir_names.cend();
+                }),
+            dirMonitors.end());
+    }
 
     // Add monitors that do not exist yet.
     std::vector<Glib::ustring> monitored_dir_names;
@@ -744,7 +782,7 @@ void FileCatalog::refreshDirectoryMonitors(const std::vector<Glib::RefPtr<Gio::F
             continue; // A monitor exists already.
         }
         auto dir_monitor = dir_to_monitor->monitor_directory();
-        dir_monitor->signal_changed().connect(sigc::bind(sigc::mem_fun(*this, &FileCatalog::on_dir_changed), false));
+        dir_monitor->signal_changed().connect(sigc::mem_fun(*this, &FileCatalog::on_dir_changed));
         dirMonitors.emplace_back(dir_monitor, dir_path);
     }
 }
@@ -779,45 +817,62 @@ void FileCatalog::enableTabMode(bool enable)
 
 void FileCatalog::_refreshProgressBar ()
 {
-    // In tab mode, no progress bar at all
-    // Also mention that this progress bar only measures the FIRST pass (quick thumbnails)
-    // The second, usually longer pass is done multithreaded down in the single entries and is NOT measured by this
-    if (!inTabMode && (!previewsToLoad || std::floor(100.f * previewsLoaded / previewsToLoad) != std::floor(100.f * (previewsLoaded - 1) / previewsToLoad))) {
+    // This progress bar only measures the FIRST pass (quick thumbnails)
+    // The second, usually longer pass is NOT measured by this
+    const auto previewsLoaded = fileBrowser->getEntries().size();
+
+    if (!progressImage || !progressLabel) {
+        // create tab label once
+        Gtk::Notebook *nb = (Gtk::Notebook *)(filepanel->get_parent());
+        Gtk::Grid* grid = Gtk::manage(new Gtk::Grid());
+        setExpandAlignProperties (grid, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
+        progressImage = Gtk::manage(new RTImage("folder-closed", Gtk::ICON_SIZE_LARGE_TOOLBAR));
+        progressLabel = Gtk::manage(new Gtk::Label(M("MAIN_FRAME_FILEBROWSER")));
 
         const auto& options = App::get().options();
-        if (!progressImage || !progressLabel) {
-            // create tab label once
-            Gtk::Notebook *nb = (Gtk::Notebook *)(filepanel->get_parent());
-            Gtk::Grid* grid = Gtk::manage(new Gtk::Grid());
-            setExpandAlignProperties (grid, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
-            progressImage = Gtk::manage(new RTImage("folder-closed", Gtk::ICON_SIZE_LARGE_TOOLBAR));
-            progressLabel = Gtk::manage(new Gtk::Label(M("MAIN_FRAME_FILEBROWSER")));
-            grid->attach_next_to(*progressImage, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
-            grid->attach_next_to(*progressLabel, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
-            grid->set_tooltip_markup(M("MAIN_FRAME_FILEBROWSER_TOOLTIP"));
-            grid->show_all();
-            if (options.mainNBVertical) {
-                progressLabel->set_angle(90);
-            }
-            if (nb) {
-                nb->set_tab_label(*filepanel, *grid);
-            }
+        grid->attach_next_to(*progressImage, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
+        grid->attach_next_to(*progressLabel, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
+        grid->set_tooltip_markup(M("MAIN_FRAME_FILEBROWSER_TOOLTIP"));
+        grid->show_all();
+        if (options.mainNBVertical) {
+            progressLabel->set_angle(90);
         }
-        if (!previewsToLoad) {
-            progressImage->set_from_icon_name("folder-closed", Gtk::ICON_SIZE_LARGE_TOOLBAR);
-            int filteredCount = min(fileBrowser->getNumFiltered(), previewsLoaded);
-            progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") +
-                                    (filteredCount != previewsLoaded ? " [" + Glib::ustring::format(filteredCount) + "/" : " (")
-                                    + Glib::ustring::format(previewsLoaded) +
-                                    (filteredCount != previewsLoaded ? "]" : ")"));
-        } else {
-            progressImage->set_from_icon_name("magnifier", Gtk::ICON_SIZE_LARGE_TOOLBAR);
-            progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") + " ["
-                                    + Glib::ustring::format(previewsLoaded) + "/"
-                                    + Glib::ustring::format(previewsToLoad) + "]" );
-            filepanel->loadingThumbs("", (double)previewsLoaded / previewsToLoad);
+        if (nb) {
+            nb->set_tab_label(*filepanel, *grid);
         }
     }
+    if (!previewsToLoad) {
+        progressImage->set_from_icon_name("folder-closed", Gtk::ICON_SIZE_LARGE_TOOLBAR);
+        const auto filteredCount = min(fileBrowser->getNumFiltered(), previewsLoaded);
+        progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") +
+                                (filteredCount != previewsLoaded ? " [" + Glib::ustring::format(filteredCount) + "/" : " [")
+                                + Glib::ustring::format(previewsLoaded) +
+                                (filteredCount != previewsLoaded ? "]" : "]"));
+    } else {
+        progressImage->set_from_icon_name("magnifier", Gtk::ICON_SIZE_LARGE_TOOLBAR);
+        progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") + " ["
+                                + Glib::ustring::format(previewsLoaded) + " ("
+                                + Glib::ustring::format(previewsToLoad) + ")]" );
+        filepanel->loadingThumbs("", (double)previewsLoaded / (previewsLoaded + previewsToLoad));
+    }
+}
+
+void FileCatalog::previewFailed(int dir_id, Glib::ustring file, FailReason reason)
+{
+    idle_register.add(
+        [this, dir_id, file, reason]() -> bool
+        {
+            if ( dir_id != selectedDirectoryId ) {
+                return false;
+            }
+
+            fileNameList.erase(std::remove(fileNameList.begin(), fileNameList.end(), file), fileNameList.end());
+            previewsToLoad--;
+
+            return false;
+        },
+        G_PRIORITY_DEFAULT_IDLE
+    );
 }
 
 void FileCatalog::previewReady (int dir_id, FileBrowserEntry* fdn)
@@ -882,7 +937,7 @@ void FileCatalog::previewReady (int dir_id, FileBrowserEntry* fdn)
                 dirEFS.expcomp.insert (cfs->expcomp);
             }
 
-            previewsLoaded++;
+            previewsToLoad--;
 
             _refreshProgressBar();
             return false;
@@ -899,7 +954,6 @@ void FileCatalog::previewsFinishedUI(int dir_id)
     }
 
     redrawAll();
-    previewsToLoad = 0;
 
     if (filterPanel) {
         filterPanel->set_sensitive(true);
@@ -1046,12 +1100,10 @@ void FileCatalog::deleteRequested(const std::vector<FileBrowserEntry*>& tbe, boo
     if (msd.run() == Gtk::RESPONSE_YES) {
         for (unsigned int i = 0; i < tbe.size(); i++) {
             const auto fname = tbe[i]->filename;
-            const auto md5 = tbe[i]->thumbnail->getMD5();
-            // remove from browser
-            delete fileBrowser->delEntry (fname);
-            // remove from cache
-            cacheMgr->clearFromCache (fname, md5, true);
-            // delete from file system
+
+            // clear cache, remove from filebrowser and delete from filesystem
+            cacheMgr->clearFromCache(fname, true);
+            delete fileBrowser->delEntry(fname);
             ::g_remove (fname.c_str ());
             // delete paramfile if found
             ::g_remove ((fname + App::PARAM_FILE_EXTENSION).c_str ());
@@ -1068,8 +1120,6 @@ void FileCatalog::deleteRequested(const std::vector<FileBrowserEntry*>& tbe, boo
                 Glib::ustring procfNameParamFile = Glib::ustring::compose ("%1.%2.out%3", BatchQueue::calcAutoFileNameBase(fname), options.saveFormatBatch.format, App::PARAM_FILE_EXTENSION);
                 ::g_remove (procfNameParamFile.c_str ());
             }
-
-            previewsLoaded--;
         }
 
         _refreshProgressBar();
@@ -1147,8 +1197,6 @@ void FileCatalog::copyMoveRequested(const std::vector<FileBrowserEntry*>& tbe, b
                         cacheMgr->renameEntry (src_fPath, tbe[i]->thumbnail->getMD5(), dest_fPath);
                         // remove from browser
                         fileBrowser->delEntry (src_fPath);
-
-                        previewsLoaded--;
                     } else {
                         src_file->copy(dest_file);
                     }
@@ -1372,7 +1420,8 @@ void FileCatalog::renameRequested(const std::vector<FileBrowserEntry*>& tbe)
                     if (::g_rename (ofname.c_str (), nfname.c_str ()) == 0) {
                         cacheMgr->renameEntry (ofname, tbe[i]->thumbnail->getMD5(), nfname);
                         ::g_remove((ofname + App::PARAM_FILE_EXTENSION).c_str ());
-                        reparseDirectory ();
+                        // skip ahead and just add the file to bypass directory monitoring timeout
+                        addFile(nfname);
                     }
                 }
             } else {
@@ -1401,9 +1450,8 @@ void FileCatalog::clearFromCacheRequested(const std::vector<FileBrowserEntry*>& 
 
     for (unsigned int i = 0; i < tbe.size(); i++) {
         Glib::ustring fname = tbe[i]->filename;
-        Glib::ustring md5 = tbe[i]->thumbnail->getMD5();
         // remove from cache
-        cacheMgr->clearFromCache (fname, md5, leavenotrace);
+        cacheMgr->clearFromCache (fname, leavenotrace);
     }
 }
 
@@ -1842,8 +1890,153 @@ bool FileCatalog::restoreResetState ()
     return ret;
 }
 
-void FileCatalog::reparseDirectory ()
+bool FileCatalog::eventDeletedFile(const Glib::RefPtr<Gio::File>& file)
+{ 
+    auto pos = std::find(fileNameList.cbegin(), fileNameList.cend(), file->get_path());
+    if (pos != fileNameList.cend()) {
+        cacheMgr->clearFromCache(file->get_path(), true);
+        delete fileBrowser->delEntry(file->get_path());
+
+        fileNameList.erase(pos);
+
+        _refreshProgressBar();
+
+        return true;
+    }
+
+    return false;
+}
+
+void FileCatalog::eventDeletedDirectory(const Glib::RefPtr<Gio::File>& directory)
 {
+    if (!directory) {
+        return;
+    }
+
+    std::vector<Glib::ustring> filesToDel;
+
+    const std::vector<ThumbBrowserEntryBase*>& t = fileBrowser->getEntries();
+    for (const auto& entry : t) {
+        // trying to match with files from the directory and its subdirectories based on path
+        if ( entry->filename.rfind(directory->get_path()) == 0 ) {
+            filesToDel.push_back(entry->filename);
+        }
+    }
+
+    bool refresh = false;
+
+    for (const auto& toDelete : filesToDel) {
+        cacheMgr->clearFromCache(toDelete, true);
+        delete fileBrowser->delEntry(toDelete);
+
+        fileNameList.erase(std::remove(fileNameList.begin(), fileNameList.end(), toDelete), fileNameList.end());
+
+        refresh = true;
+    }
+
+    // if the directory is being cut out, the subfolders will not get their own events
+    // deleting all monitors that start with a matching path
+    dirMonitors.erase(std::remove_if(dirMonitors.begin(), dirMonitors.end(),
+                    [&directory](const FileMonitorInfo &fileMonitorInfo) { return (fileMonitorInfo.filePath.rfind(directory->get_path(), 0) == 0); })
+                    , dirMonitors.end());
+
+    if (refresh) {
+        _refreshProgressBar();
+    }
+}
+
+void FileCatalog::eventDirectoryCreated(const Glib::RefPtr<Gio::File>& directory)
+{
+    const auto& options = App::get().options();
+
+    if (!options.browseRecursive) {
+        return;
+    }
+
+    int recursiondepth = GetRecursionDepth(selectedDirectory, directory);
+
+    if (recursiondepth > options.browseRecursiveDepth) {
+        return;
+    }
+
+    if (std::find_if(dirMonitors.cbegin(), dirMonitors.cend(), 
+                    [&directory](const FileMonitorInfo &fileMonitorInfo) { return fileMonitorInfo.filePath == directory->get_path(); }
+                    ) != dirMonitors.cend()) {
+        // the monitor already exists
+        return;
+    }
+
+    // only creating monitor, the files get individual events
+    auto dir_path = directory->get_path();
+    auto dir_monitor = directory->monitor_directory();
+    dir_monitor->signal_changed().connect(sigc::mem_fun(*this, &FileCatalog::on_dir_changed));
+    dirMonitors.emplace_back(dir_monitor, dir_path);
+}
+
+void FileCatalog::eventChangesDoneDirectory(const Glib::RefPtr<Gio::File>& directory)
+{
+    const auto& options = App::get().options();
+
+    if (!options.browseRecursive) {
+        return;
+    }
+
+    int recursiondepth = GetRecursionDepth(selectedDirectory, directory);
+
+    if (recursiondepth > options.browseRecursiveDepth) {
+        return;
+    }
+    // Motivation for having a recursive search for files and directories:
+    // * If the directory was cut&pasted, there are no events for individual files
+    // * Also, sometimes events come in wrong order (files before dir), in which case a file could have been left undiscovered
+
+    // build a set of collate-keys for faster search
+    std::set<std::string> oldNames;
+    for (const auto& oldName : fileNameList) {
+        oldNames.insert(oldName.collate_key());
+    }
+
+    std::vector<Glib::RefPtr<Gio::File>> allDirs;
+    std::vector<Glib::ustring> fileList = getFileList(directory->get_path(), recursiondepth, &allDirs);
+    for (const auto& newName : fileList) {
+        if (oldNames.find(newName.collate_key()) == oldNames.end()) {
+            addToPendingFiles(newName);
+        }
+    }
+    _refreshProgressBar();
+
+    refreshDirectoryMonitors(allDirs, true);
+}
+
+void FileCatalog::eventChangesDoneFile(const Glib::RefPtr<Gio::File>& file)
+{
+    auto pendingFile = std::find_if(pendingFiles.begin(), pendingFiles.end(),
+                                    [&file](const std::pair<FileCClock::time_point,Glib::ustring>& element){ return element.second == file->get_path(); });
+    if (pendingFile != pendingFiles.end()) {
+        pendingFile->first = FileCClock::now();
+    } else {
+        if (std::find(fileNameList.cbegin(), fileNameList.cend(), file->get_path()) == fileNameList.cend()) {
+            // Probably the thumbnail has failed previously, re-adding it now as the file has had changes written to it
+            pendingFiles.push_back(std::make_pair(FileCClock::now(),file->get_path()));
+        }
+    }
+}
+
+void FileCatalog::on_dir_changed (const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type)
+{
+    if (event_type == Gio::FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED) {
+        return;
+    }
+
+    if (event_type == Gio::FILE_MONITOR_EVENT_CHANGED) {
+        // CHANGED event only updates times in pendingFiles if there are any, be done with that as fast as possible
+        auto pendingFile = std::find_if(pendingFiles.begin(), pendingFiles.end(),
+                                        [&file](const std::pair<FileCClock::time_point,Glib::ustring>& e){ return e.second == file->get_path(); });
+        if (pendingFile != pendingFiles.end()) {
+            pendingFile->first = FileCClock::now();
+        }
+        return;
+    }
 
     if (selectedDirectory.empty()) {
         return;
@@ -1854,65 +2047,86 @@ void FileCatalog::reparseDirectory ()
         return;
     }
 
-    // check if a thumbnailed file has been deleted or is not in a directory of interest
-    const std::vector<ThumbBrowserEntryBase*>& t = fileBrowser->getEntries();
-    std::vector<Glib::ustring> fileNamesToRemove;
+    bool isDirectory = Glib::file_test(file->get_path(), Glib::FileTest::FILE_TEST_IS_DIR);
 
-    for (const auto& entry : t) {
-        if (!Glib::file_test(entry->filename, Glib::FILE_TEST_EXISTS)) {
-            cacheMgr->clearFromCache(entry->filename, entry->thumbnail->getMD5(), true);
-            fileNamesToRemove.push_back(entry->filename);
-        }
-        else if (!App::get().options().browseRecursive && Glib::path_get_dirname(entry->filename) != selectedDirectory) {
-            fileNamesToRemove.push_back(entry->filename);
-        }
+    if (!isDirectory && !App::get().options().has_retained_extention(file->get_parse_name())
+                     && !(event_type == Gio::FILE_MONITOR_EVENT_DELETED)) {
+        return;
     }
 
-    for (const auto& toRemove : fileNamesToRemove) {
-        delete fileBrowser->delEntry(toRemove);
-        --previewsLoaded;
-    }
+    // Notes for future reference:
+    // * Some events get duplicated at least when monitoring an SMB drive connected to a Windows 10
+    // * Gio::FileMonitor blocks deletes and or delete events on the monitored items (on RawTherapee this means directories, no problems with files) on SMB network shares on Windows 10.
 
-    if (!fileNamesToRemove.empty()) {
+    switch (event_type) {
+        case Gio::FILE_MONITOR_EVENT_CREATED:
+            if (isDirectory) {
+                eventDirectoryCreated(file);
+            }
+            break;
+        case Gio::FILE_MONITOR_EVENT_CHANGES_DONE_HINT:
+            if (!isDirectory) {
+                eventChangesDoneFile(file);
+            } else {
+                eventChangesDoneDirectory(file);
+            }  
+            break;
+        case Gio::FILE_MONITOR_EVENT_DELETED:
+            if ( !eventDeletedFile(file) ) {
+                // There is no way to test, that I know of, if the passed file parameter refers to a file or a directory.
+                // So the logic is: if the eventDeletedFile fails, it is a directory.
+                // this will cause overhead, when events for already handled files come but to resolve it completely may need some reorganization of data
+                eventDeletedDirectory(file);
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+bool FileCatalog::timerEvents()
+{
+    //
+    // Delayed thumbnail generation
+    // There are many bugs happening if the thumbnail generation is attempted too early. These include failed thumbnails
+    // and crashes when processed images are saved to the monitored directory.
+    bool fileAdded = false;
+    for (auto it = pendingFiles.begin(); it != pendingFiles.end(); ) {
+        auto since = std::chrono::duration_cast<std::chrono::milliseconds>(FileCClock::now()-it->first);
+        if (since.count() > (App::get().options().newFileDelayTime * 1000)){
+            if (std::find(fileNameList.cbegin(), fileNameList.cend(), it->second) == fileNameList.cend()) {
+                addFile(it->second);
+                fileAdded = true;
+            }
+
+            it = pendingFiles.erase(it);
+        } else {
+            it++;
+        }
+    }
+    if (fileAdded) {
+        filepanel->loadingThumbs(M("PROGRESSBAR_LOADINGTHUMBS"), 0);
         _refreshProgressBar();
     }
 
-    // check if a new file has been added
-    // build a set of collate-keys for faster search
-    std::set<std::string> oldNames;
-    for (const auto& oldName : fileNameList) {
-        oldNames.insert(oldName.collate_key());
-    }
-
-    std::vector<Glib::RefPtr<Gio::File>> allDirs;
-    fileNameList = getFileList(&allDirs);
-    for (const auto& newName : fileNameList) {
-        if (oldNames.find(newName.collate_key()) == oldNames.end()) {
-            addFile(newName);
-            _refreshProgressBar();
-        }
-    }
-
-    refreshDirectoryMonitors(allDirs);
-}
-
-void FileCatalog::on_dir_changed (const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type, bool internal)
-{
-
-    if ((App::get().options().has_retained_extention(file->get_parse_name())
-            && (event_type == Gio::FILE_MONITOR_EVENT_CREATED || event_type == Gio::FILE_MONITOR_EVENT_DELETED || event_type == Gio::FILE_MONITOR_EVENT_CHANGED))
-             || (event_type == Gio::FILE_MONITOR_EVENT_CREATED && Glib::file_test(file->get_path(), Glib::FileTest::FILE_TEST_IS_DIR))
-             || (event_type == Gio::FILE_MONITOR_EVENT_DELETED && std::find_if(dirMonitors.cbegin(), dirMonitors.cend(), [&file](const FileMonitorInfo &monitor) { return monitor.filePath == file->get_path(); }) != dirMonitors.cend()))
-    {
-        reparseDirectory ();
-    }
+    return true;
 }
 
 void FileCatalog::addFile (const Glib::ustring& fName)
 {
     if (!fName.empty()) {
+        fileNameList.push_back(fName);
         previewLoader->add(selectedDirectoryId, fName, this);
         previewsToLoad++;
+    }
+}
+
+void FileCatalog::addToPendingFiles (const Glib::ustring& fName)
+{
+    auto found = std::find_if(pendingFiles.cbegin(), pendingFiles.cend(),
+                            [&fName](const std::pair<FileCClock::time_point,Glib::ustring>& e){ return e.second == fName; });
+    if (found == pendingFiles.cend()) {
+        pendingFiles.push_back(std::make_pair(FileCClock::now(), fName));
     }
 }
 

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1969,7 +1969,7 @@ void FileCatalog::eventDirectoryCreated(const Glib::RefPtr<Gio::File>& directory
 
     int recursiondepth = GetRecursionDepth(selectedDirectory, directory);
 
-    if (recursiondepth > options.browseRecursiveDepth) {
+    if (recursiondepth > options.browseRecursiveDepth || static_cast<int>(dirMonitors.size()) >= options.browseRecursiveMaxDirs) {
         return;
     }
 
@@ -1997,7 +1997,7 @@ void FileCatalog::eventChangesDoneDirectory(const Glib::RefPtr<Gio::File>& direc
 
     int recursiondepth = GetRecursionDepth(selectedDirectory, directory);
 
-    if (recursiondepth > options.browseRecursiveDepth) {
+    if (recursiondepth > options.browseRecursiveDepth || static_cast<int>(dirMonitors.size()) >= options.browseRecursiveMaxDirs) {
         return;
     }
     // Motivation for having a recursive search for files and directories:

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -54,6 +54,8 @@ public:
     typedef sigc::slot<void, const Glib::ustring&> DirSelectionSlot;
 
 private:
+    typedef std::chrono::system_clock FileCClock;
+
     struct FileMonitorInfo {
         FileMonitorInfo(const Glib::RefPtr<Gio::FileMonitor> &file_monitor, const Glib::ustring &file_path) :
             fileMonitor(file_monitor), filePath(file_path) {}
@@ -154,11 +156,10 @@ private:
     FilterPanel* filterPanel;
     ExportPanel* exportPanel;
 
-    int previewsToLoad;
-    int previewsLoaded;
+    std::size_t previewsToLoad;
 
-
-    std::vector<Glib::ustring> fileNameList;
+    std::vector<Glib::ustring> fileNameList;                ///< Currently managed files.
+    std::vector<std::pair<FileCClock::time_point,Glib::ustring>> pendingFiles; ///< Files that have been created but are not yet managed.
     std::set<Glib::ustring> editedFiles;
     guint modifierKey; // any modifiers held when rank button was pressed
 
@@ -166,12 +167,22 @@ private:
 
     IdleRegister idle_register;
 
+    sigc::connection   timerEventSource;                    ///< File monitoring timer
+
     void addAndOpenFile (const Glib::ustring& fname);
     void addFile (const Glib::ustring& fName);
+    void addToPendingFiles (const Glib::ustring& fName);
     std::vector<Glib::ustring> getFileList(std::vector<Glib::RefPtr<Gio::File>> *dirs_explored = nullptr);
+    std::vector<Glib::ustring> getFileList(Glib::ustring root, int start_depth, std::vector<Glib::RefPtr<Gio::File>> *dirs_explored = nullptr);
     BrowserFilter getFilter ();
-    void refreshDirectoryMonitors(const std::vector<Glib::RefPtr<Gio::File>> &dirs_to_monitor);
+    void refreshDirectoryMonitors(const std::vector<Glib::RefPtr<Gio::File>> &dirs_to_monitor, bool compound_update = false);
     void trashChanged ();
+
+    bool eventDeletedFile(const Glib::RefPtr<Gio::File>& file);
+    void eventDeletedDirectory(const Glib::RefPtr<Gio::File>& directory);
+    void eventDirectoryCreated(const Glib::RefPtr<Gio::File>& directory);
+    void eventChangesDoneDirectory(const Glib::RefPtr<Gio::File>& directory);
+    void eventChangesDoneFile(const Glib::RefPtr<Gio::File>& file);
 
 public:
     // thumbnail browsers
@@ -187,6 +198,7 @@ public:
     void refreshEditedState (const std::set<Glib::ustring>& efiles);
 
     // previewloaderlistener interface
+    void previewFailed(int dir_id, Glib::ustring file, FailReason reason) override;
     void previewReady (int dir_id, FileBrowserEntry* fdn) override;
     void previewsFinished (int dir_id) override;
     // called asynchronously from the main event loop
@@ -270,7 +282,6 @@ public:
     bool restoreResetState ();
 
     void on_realize() override;
-    void reparseDirectory ();
     void _openImage (const std::vector<Thumbnail*>& tmb);
 
     void zoomIn ();
@@ -311,8 +322,9 @@ public:
     void showToolBar();
     void hideToolBar();
 
-    void on_dir_changed (const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type, bool internal);
+    void on_dir_changed (const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type);
 
+    bool timerEvents();
 };
 
 inline void FileCatalog::setDirSelector (const FileCatalog::DirSelectionSlot& selectDir)

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -473,6 +473,7 @@ void Options::setDefaults()
     browseRecursiveDepth = 10;
     browseRecursiveMaxDirs = 100;
     browseRecursiveFollowLinks = true;
+    newFileDelayTime = 2;
     renameUseTemplates = false;
     renameTemplates.clear();
     thumbnailZoomRatios.clear();
@@ -1411,6 +1412,10 @@ void Options::readFromFile(Glib::ustring fname)
 
                 if (keyFile.has_key("File Browser", "BrowseRecursiveFollowLinks")) {
                     browseRecursiveFollowLinks = keyFile.get_boolean("File Browser", "BrowseRecursiveFollowLinks");
+                }
+
+                if (keyFile.has_key("File Browser", "BrowseRecursiveFollowLinks")) {
+                    newFileDelayTime = keyFile.get_integer("File Browser", "NewFileDelayTime");
                 }
 
                 if (keyFile.has_key("File Browser", "ThumbnailRankColorMode")) {
@@ -2549,6 +2554,7 @@ void Options::saveToFile(Glib::ustring fname)
         keyFile.set_integer("File Browser", "BrowseRecursiveDepth", browseRecursiveDepth);
         keyFile.set_integer("File Browser", "BrowseRecursiveMaxDirs", browseRecursiveMaxDirs);
         keyFile.set_boolean("File Browser", "BrowseRecursiveFollowLinks", browseRecursiveFollowLinks);
+        keyFile.set_integer("File Browser", "NewFileDelayTime", newFileDelayTime);
         keyFile.set_integer("Clipping Indication", "HighlightThreshold", highlightThreshold);
         keyFile.set_integer("Clipping Indication", "ShadowThreshold", shadowThreshold);
         keyFile.set_boolean("Clipping Indication", "BlinkClipped", blinkClipped);

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -1414,7 +1414,7 @@ void Options::readFromFile(Glib::ustring fname)
                     browseRecursiveFollowLinks = keyFile.get_boolean("File Browser", "BrowseRecursiveFollowLinks");
                 }
 
-                if (keyFile.has_key("File Browser", "BrowseRecursiveFollowLinks")) {
+                if (keyFile.has_key("File Browser", "NewFileDelayTime")) {
                     newFileDelayTime = keyFile.get_integer("File Browser", "NewFileDelayTime");
                 }
 

--- a/rtgui/options.h
+++ b/rtgui/options.h
@@ -326,6 +326,7 @@ public:
     int browseRecursiveDepth;
     int browseRecursiveMaxDirs;
     bool browseRecursiveFollowLinks;
+    int newFileDelayTime;           ///< Minimum time in seconds to wait for a new file to be idle before generating a thumbnail for it. Delay is not exact, it can vary almost a full second upwards.
     std::vector<int> tpOpen;
     bool autoSaveTpOpen;
     //std::vector<int> crvOpen;

--- a/rtgui/previewloader.cc
+++ b/rtgui/previewloader.cc
@@ -126,12 +126,16 @@ public:
             {
                 if (Glib::file_test(j.dir_entry_, Glib::FILE_TEST_EXISTS)) {
                     tmb = cacheMgr->getEntry(j.dir_entry_);
+                } else {
+                    j.listener_->previewFailed(j.dir_id_, j.dir_entry_, PreviewLoaderListener::FailReason::FILEDOESNOTEXIST);
                 }
             }
 
-            if ( tmb ) {
+            if (tmb) {
                 DEBUG("Preview Ready\n");
                 j.listener_->previewReady(j.dir_id_, new FileBrowserEntry(tmb, j.dir_entry_));
+            } else {
+                j.listener_->previewFailed(j.dir_id_, j.dir_entry_, PreviewLoaderListener::FailReason::THUMBNAILFAILED);
             }
 
         } catch (Glib::Error &e) {} catch(...) {}

--- a/rtgui/previewloader.cc
+++ b/rtgui/previewloader.cc
@@ -123,21 +123,19 @@ public:
         // do processing unlocked
         try {
             Thumbnail* tmb = nullptr;
-            {
-                if (Glib::file_test(j.dir_entry_, Glib::FILE_TEST_EXISTS)) {
-                    tmb = cacheMgr->getEntry(j.dir_entry_);
+
+            if (Glib::file_test(j.dir_entry_, Glib::FILE_TEST_EXISTS)) {
+                tmb = cacheMgr->getEntry(j.dir_entry_);
+
+                if (tmb) {
+                    DEBUG("Preview Ready\n");
+                    j.listener_->previewReady(j.dir_id_, new FileBrowserEntry(tmb, j.dir_entry_));
                 } else {
-                    j.listener_->previewFailed(j.dir_id_, j.dir_entry_, PreviewLoaderListener::FailReason::FILEDOESNOTEXIST);
+                    j.listener_->previewFailed(j.dir_id_, j.dir_entry_, PreviewLoaderListener::FailReason::THUMBNAILFAILED);
                 }
-            }
-
-            if (tmb) {
-                DEBUG("Preview Ready\n");
-                j.listener_->previewReady(j.dir_id_, new FileBrowserEntry(tmb, j.dir_entry_));
             } else {
-                j.listener_->previewFailed(j.dir_id_, j.dir_entry_, PreviewLoaderListener::FailReason::THUMBNAILFAILED);
+                j.listener_->previewFailed(j.dir_id_, j.dir_entry_, PreviewLoaderListener::FailReason::FILEDOESNOTEXIST);
             }
-
         } catch (Glib::Error &e) {} catch(...) {}
 
         bool notifyListener = false;

--- a/rtgui/previewloader.h
+++ b/rtgui/previewloader.h
@@ -34,6 +34,14 @@ class FileBrowserEntry;
 class PreviewLoaderListener
 {
 public:
+    /**
+     * @brief Reason the PreviewLoader failed to generate thumbnail
+     */
+    enum class FailReason{
+        FILEDOESNOTEXIST,   ///< File was not found
+        THUMBNAILFAILED     ///< Generating thumbnail from the file failed.
+    };
+
     virtual ~PreviewLoaderListener() = default;
 
     /**
@@ -48,6 +56,14 @@ public:
      * @brief all previews have finished loading
      */
     virtual void previewsFinished(int dir_id_) = 0;
+
+    /**
+     * @brief creating the preview failed
+     * 
+     * @param dir_id directory ID this is for
+     * @param file name of the failed file, including the path
+     */
+    virtual void previewFailed(int dir_id, Glib::ustring file, FailReason reason) = 0;
 };
 
 class PreviewLoader :

--- a/rtgui/previewloader.h
+++ b/rtgui/previewloader.h
@@ -62,6 +62,7 @@ public:
      * 
      * @param dir_id directory ID this is for
      * @param file name of the failed file, including the path
+     * @param reason a more specific explanation for the failure
      */
     virtual void previewFailed(int dir_id, Glib::ustring file, FailReason reason) = 0;
 };

--- a/rtgui/windows/preferences.cc
+++ b/rtgui/windows/preferences.cc
@@ -1563,6 +1563,18 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
     vbro->pack_start(*browseRecursiveFollowLinks, Gtk::PACK_SHRINK, 0);
 #endif
 
+    Gtk::Box *hbFileDelayTime = Gtk::manage(new Gtk::Box());
+    Gtk::Label *labMininmumFileBrowserDelayTime = Gtk::manage(new Gtk::Label(M("PREFERENCES_BROWSERTIMEOUT") + ":"));
+    labMininmumFileBrowserDelayTime->set_tooltip_markup(M("PREFERENCES_BROWSERTIMEOUTHINT"));
+    newFileDelayTime = Gtk::manage(new Gtk::SpinButton());
+    newFileDelayTime->set_tooltip_markup(M("PREFERENCES_BROWSERTIMEOUTHINT"));
+    newFileDelayTime->set_digits(0);
+    newFileDelayTime->set_increments(1, 5);
+    newFileDelayTime->set_range(0, 30);
+    hbFileDelayTime->pack_start(*labMininmumFileBrowserDelayTime, Gtk::PACK_SHRINK, 4);
+    hbFileDelayTime->pack_start(*newFileDelayTime, Gtk::PACK_SHRINK, 4);
+    vbro->pack_start(*hbFileDelayTime, Gtk::PACK_SHRINK, 0);
+
     fro->add(*vbro);
 
 
@@ -2031,6 +2043,7 @@ void Preferences::storePreferences()
     if (browseRecursiveFollowLinks) {
         moptions.browseRecursiveFollowLinks = browseRecursiveFollowLinks->get_active();
     }
+    moptions.newFileDelayTime = static_cast<int>(newFileDelayTime->get_value());
 
     auto save_where = saveParamsPreference->get_active_row_number();
     moptions.saveParamsFile = save_where == 0 || save_where == 2;
@@ -2272,6 +2285,7 @@ void Preferences::fillPreferences()
     if (browseRecursiveFollowLinks) {
         browseRecursiveFollowLinks->set_active(moptions.browseRecursiveFollowLinks);
     }
+    newFileDelayTime->set_value(moptions.newFileDelayTime);
 
     saveParamsPreference->set_active(moptions.saveParamsFile ? (moptions.saveParamsCache ? 2 : 0) : 1);
 

--- a/rtgui/windows/preferences.cc
+++ b/rtgui/windows/preferences.cc
@@ -1564,14 +1564,14 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
 #endif
 
     Gtk::Box *hbFileDelayTime = Gtk::manage(new Gtk::Box());
-    Gtk::Label *labMininmumFileBrowserDelayTime = Gtk::manage(new Gtk::Label(M("PREFERENCES_BROWSERTIMEOUT") + ":"));
-    labMininmumFileBrowserDelayTime->set_tooltip_markup(M("PREFERENCES_BROWSERTIMEOUTHINT"));
+    Gtk::Label *labMinimumFileBrowserDelayTime = Gtk::manage(new Gtk::Label(M("PREFERENCES_BROWSERTIMEOUT") + ":"));
+    labMinimumFileBrowserDelayTime->set_tooltip_markup(M("PREFERENCES_BROWSERTIMEOUTHINT"));
     newFileDelayTime = Gtk::manage(new Gtk::SpinButton());
     newFileDelayTime->set_tooltip_markup(M("PREFERENCES_BROWSERTIMEOUTHINT"));
     newFileDelayTime->set_digits(0);
     newFileDelayTime->set_increments(1, 5);
     newFileDelayTime->set_range(0, 30);
-    hbFileDelayTime->pack_start(*labMininmumFileBrowserDelayTime, Gtk::PACK_SHRINK, 4);
+    hbFileDelayTime->pack_start(*labMinimumFileBrowserDelayTime, Gtk::PACK_SHRINK, 4);
     hbFileDelayTime->pack_start(*newFileDelayTime, Gtk::PACK_SHRINK, 4);
     vbro->pack_start(*hbFileDelayTime, Gtk::PACK_SHRINK, 0);
 

--- a/rtgui/windows/preferences.h
+++ b/rtgui/windows/preferences.h
@@ -191,6 +191,7 @@ class Preferences final :
     Gtk::SpinButton* browseRecursiveDepth;
     Gtk::SpinButton* browseRecursiveMaxDirs;
     Gtk::CheckButton* browseRecursiveFollowLinks{nullptr};
+    Gtk::SpinButton* newFileDelayTime;
 
     Gtk::SpinButton*  threadsSpinBtn;
     Gtk::SpinButton*  clutCacheSizeSB;


### PR DESCRIPTION
## Goal
RawTherapee UI has a tendency to have responsiveness issues when filesystem events happen. This is happening because the `FileCatalog` reparses the directory everytime any event happens. Some events do get filtered out but that is insufficient. On my testing, the time it takes to reparse largish (~2000 images) directory once fluctuates from few milliseconds to almost a second. When repeated, the time tends to speed up. However, when plenty of events happen, the UI can freeze for several minutes as there will be hundreds of events queued. User can also make it worse with user actions while the UI is frozen. This PR implements specific and fast handling for all events RawTherapee uses as they happen.

While I have been making this PR I found various bugs during the development and testing for which I have been making separate PRs. Now that I have run out of those bugs, I think it is time to introduce this PR.

I have previously made a PR that changes the `progressBar_` handling #7594, which is included in this PR. I will close it, but I can open it again and it can be reviewed as a separate PR if wanted.

## Issues this PR fixes
- When copying files to the observed directory, RawTherapee has serious responsiveness issues. Seriousness depends on exact details. Secondarily, most often at least some of the files will stay missing until the directory is refreshed from the UI.
- #7311 - When deleting files, from trash or with external program, the RawTherapee is loaded by events. Each event will block the UI until it finishes reparsing the directory.
- If thumbnail generation is attempted with an incomplete image file, RawTherapee can crash. I found out this during testing as with increased speed of event handling, the crashes became more frequent when saving files for example. This PR implements a delay timer, which holds the RawTherapee from starting thumbnail processing until the file has been idle for a while. #4686
- When files are being copied to a monitored directory, currently they tend to just not appear. This is usually caused by RawTherapee trying to generate a thumbnail from an incomplete file and failing. #5102
- New files copied/saved to the File Browser directory may have corrupted thumbnails. This is happening because the thumbnail generation is attempted with incomplete files. Based on the description, this #5086 could be caused by this. RawTherapee has a tendency to not reprocess cached thumbnails unless you actually do something. I couldn't get past this issue during early development before adding the timer.

List of issues: #7311, #4686, #5102, #5086
Issues that could be related, but the description is insufficient for proper link: #3593
This PR invalidates: #7310
This PR includes the changes in: #7594

## More detailed list of changes
- `reparseDirectory` is removed and `FileCatalog::on_dir_changed` now calls specific event handlers.
- Timer was added. Users can adjust the delay through preferences. Valid range is between 1 and 30. If user sets the value to 0, the `FileCatalog` will not monitor the current directory.
- The `DirBrowser` now handles normal events individually. This is not a big performance improvement, but it is more of a consistency with the methods used in `FileCatalog`.
- There is no point trying to track moves. The events have such a big variation on parameters it would be messy to make it robust and there is very little potential for performance benefits to be gained. Removed everything related to that.
- Removed deprecated `GThreadLock` use from `DirBrowser`.
- Cleaned out dead Windows code from DirBrowser.
- The trampoline type Windows timer was replaced with `Glib::signal_timeout()`. It should be safe because everything related is executed in the UI thread.
- The progress bar is now updated more frequently and it is more consistent. The code is cleaner for the progress bar as it doesn't try to track the number of files added to the container.
- Users have more detailed information of file system events as the `progressBar_` doesn't try to limit visible changes.
- New `PreviewLoaderListener` interface function `previewFailed`.

### Things not addressed
- If a file already added to the File Browser gets updated on the disk, it will not get updated in RawTherapee. This is how it used to work before also.

## About filesystem events
There are no real filesystem events for work started and work is now finished. All the events the RawTherapee handles have been invented in the Gtk::Gio. Practically, Gtk just polls the file system and tries to guess what would be appropriate and safe at any time. This results some variablity and even small bugs here and there. In general, it would be usually enough if `FILE_MONITOR_EVENT_CHANGES_DONE_HINT` would be used to identify an added file. However, during testing it became apparent, sometimes this is called before the file is actually copied or fully copied resulting serious bugs. On the other hand, on Windows SMB drives there is a tendency to get a bunch of `FILE_MONITOR_EVENT_CREATED` events and then files are being copied one by one. In the most well behaved case we get a `FILE_MONITOR_EVENT_CREATED`, bunch of `FILE_MONITOR_EVENT_CHANGED` events, one `FILE_MONITOR_EVENT_CHANGES_DONE_HINT` event and at the end, couple of `FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED` events. One clearly buggy behavior found during testing is that on Windows, if `GFileMonitor` is attached to a directory on an SMB drive, that directory entry will not get any events when it is being deleted and the delete will not proceed until the monitor is detached from it. This can give surprising results if user has recursion enabled on a Windows SMB drive and the user tries to delete directory tree with an external program. The files themselves in the monitored directory will get events normally and will be deleted.

## Screenshots of visual changes in the UI
Progress bar: Screenshots in #7594
Preferences: 
<img width="528" height="369" alt="Screenshot_2026-04-15_14-58-05" src="https://github.com/user-attachments/assets/9b31f98e-d6c8-40c0-a12f-6c08917d79c1" />


## Testing
The PR was developed using Windows 10 and Linux actively. I'm pretty confident these systems work pretty well. I have no access to Macs and those are completely untested. I would expect the normal filesystems to work fine. What I learned from Windows 10 is that there are quite a few small issues related to Gio::FileMonitor especially when dealing with SMB folders. Similar issues could become apparent with Macs.

### Unrelated issue that could influence testing results
- When deleting a file during the second pass of thumbnail generation. While the `ThumbImageUpdater` is upgrading thumbnails based on the processing profiles, the UI will freeze until the background threads finish. This can take minutes depending on the amount of images without fully processed cached thumbnails. This is probably happening because the UI will sit with a mutex somewhere. The `ThumbImageUpdater` doesn't interact with the `CacheManager`, so this is probably some mutex within the Thumbnails.

## Next from here
- Continue optimizing experience by changing the File Browser to run thumbnail updater to only those images that are visible in the File Browser- I have already done something with that and the benefits are clear. But the code felt hacky.
- Users could be informed of all the images that failed to generate the thumbnail. The implementation would be relatively trivial with the new interface function and user would get alerted of possible file corruptions during larger copies or could investigate what files don't work well with RawTherapee.