### PR TITLE
rtengine: Remove rtgui includes

### DIFF
--- a/rtengine/color.h
+++ b/rtengine/color.h
@@ -34,6 +34,10 @@ class ustring;
 namespace rtengine
 {
 
+//OFFSET_MODIFIER and CIExy_MARGIN - Regarding the conversion of xy data to Labgrid coordinates
+constexpr float OFFSET_MODIFIER = 1.81818f;//Scaling coefficient of primary data and CIExy diagram with that of Labgrid.
+constexpr float CIExy_MARGIN = 0.1f;//corresponds to the left and bottom margin on the CIExy diagram
+
 typedef std::array<double, 7> GammaValues;
 
 class Color

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -41,7 +41,6 @@
 #include "refreshmap.h"
 #include "utils.h"
 #include "rt_algo.h"
-#include "rtgui/labgrid.h"
 
 #include "rtgui/options.h"
 

--- a/rtengine/iplab2rgb.cc
+++ b/rtengine/iplab2rgb.cc
@@ -31,7 +31,6 @@
 #include "settings.h"
 #include "utils.h"
 #include <fmt/format.h>
-#include "rtgui/labgrid.h"
 
 namespace rtengine
 {

--- a/rtgui/labgrid.h
+++ b/rtgui/labgrid.h
@@ -41,16 +41,10 @@
 #include <gtkmm.h>
 
 #include "rtengine/improcfun.h"
+#include "rtengine/color.h"
 
 #include "eventmapper.h"
 #include "toolpanel.h"
-
-namespace rtengine
-{
-    //OFFSET_MODIFIER and CIExy_MARGIN - Regarding the conversion of xy data to Labgrid coordinates
-    constexpr float OFFSET_MODIFIER = 1.81818f;//Scaling coefficient of primary data and CIExy diagram with that of Labgrid.
-    constexpr float CIExy_MARGIN = 0.1f;//corresponds to the left and bottom margin on the CIExy diagram
-}
 
 class LabGridArea final : public Gtk::DrawingArea {
 public:


### PR DESCRIPTION
So that building rtengine rely less on rtgui.
Added rtengine/labgrid.h for the interesting symbols.