### PR TITLE
Avoid batch queue preview update deadlocks

### DIFF
--- a/rtgui/batchqueueentry.cc
+++ b/rtgui/batchqueueentry.cc
@@ -65,6 +65,7 @@ BatchQueueEntry::~BatchQueueEntry ()
 {
 
     batchQueueEntryUpdater.removeJobs (this);
+    idle_register.destroy ();
 
     if (opreview) {
         delete [] opreview;
@@ -204,33 +205,41 @@ std::tuple<Glib::ustring, bool> BatchQueueEntry::getToolTip (int x, int y) const
 void BatchQueueEntry::updateImage (guint8* img, hidpi::LogicalSize size, int deviceScale,
                                    int origw, int origh, guint8* newOPreview)
 {
-    // since the update itself is already called in an async thread and there are problem with accessing opreview in thumbbrowserbase,
-    // it's safer to do this synchronously
-    {
-        GThreadLock lock;
-
-        _updateImage(img, size, deviceScale);
-    }
+    // Updating from the worker under GThreadLock can deadlock with drawing or
+    // layout code holding the GTK lock while it waits for lockRW.
+    idle_register.add(
+        [this, img, size, deviceScale] () -> bool
+        {
+            _updateImage(img, size, deviceScale);
+            return false;
+        },
+        G_PRIORITY_LOW
+    );
 }
 
 void BatchQueueEntry::_updateImage (guint8* img, hidpi::LogicalSize size, int deviceScale)
 {
-    if (previewSize.height == size.height && pendingDeviceScale == deviceScale) {
+    bool imageUpdated = false;
+
+    {
         MYWRITERLOCK(l, lockRW);
 
-        previewSize.width = size.width;
-        activeDeviceScale = pendingDeviceScale;
-        previewDataLayout.width = size.width * deviceScale;
-        previewDataLayout.height = size.height * deviceScale;
-        int dataSize = previewDataLayout.width * previewDataLayout.height * 3;
-        preview.resize(dataSize);
-        std::copy(img, img + preview.size(), preview.begin());
+        if (previewSize.height == size.height && pendingDeviceScale == deviceScale) {
+            previewSize.width = size.width;
+            activeDeviceScale = pendingDeviceScale;
+            previewDataLayout.width = size.width * deviceScale;
+            previewDataLayout.height = size.height * deviceScale;
+            int dataSize = previewDataLayout.width * previewDataLayout.height * 3;
+            preview.resize(dataSize);
+            std::copy(img, img + preview.size(), preview.begin());
 
-        if (parent) {
-            parent->redrawNeeded (this);
+            imageUpdated = true;
         }
     }
 
     delete [] img;
-}
 
+    if (imageUpdated && parent) {
+        parent->redrawNeeded (this);
+    }
+}

--- a/rtgui/batchqueueentry.h
+++ b/rtgui/batchqueueentry.h
@@ -23,6 +23,7 @@
 #include <gtkmm.h>
 
 #include "bqentryupdater.h"
+#include "guiutils.h"
 #include "options.h"
 #include "thumbbrowserentrybase.h"
 
@@ -51,6 +52,7 @@ class BatchQueueEntry final : public ThumbBrowserEntryBase, public BQEntryUpdate
     int origpw, origph;
     bool opreviewDone;
     static bool iconsLoaded;
+    IdleRegister idle_register;
 
 public:
 

--- a/rtgui/bqentryupdater.cc
+++ b/rtgui/bqentryupdater.cc
@@ -42,7 +42,7 @@ void thumbInterp(const unsigned char* src, int sw, int sh, unsigned char* dst, i
 BatchQueueEntryUpdater batchQueueEntryUpdater;
 
 BatchQueueEntryUpdater::BatchQueueEntryUpdater ()
-    : tostop(false), stopped(true), thread(nullptr), qMutex(nullptr)
+    : tostop(false), stopped(true), thread(nullptr), qMutex(nullptr), activeListener(nullptr)
 {
 }
 
@@ -115,6 +115,9 @@ void BatchQueueEntryUpdater::processThread ()
         if (!isEmpty) {
             current = jqueue.front ();
             jqueue.pop_front ();
+            // removeJobs() waits for this callback to finish before its
+            // listener can be destroyed.
+            activeListener = current.listener;
         }
 
         qMutex->unlock ();
@@ -173,6 +176,11 @@ void BatchQueueEntryUpdater::processThread ()
             delete[] current.oimg;
             current.oimg = nullptr;
         }
+
+        qMutex->lock ();
+        activeListener = nullptr;
+        inactive.notify_all ();
+        qMutex->unlock ();
     }
 
     stopped = true;
@@ -185,7 +193,7 @@ void BatchQueueEntryUpdater::removeJobs (BQEntryUpdateListener* listener)
         return;
     }
 
-    qMutex->lock ();
+    std::unique_lock<MyMutex> lock (*qMutex);
     bool ready = false;
 
     while (!ready) {
@@ -200,7 +208,7 @@ void BatchQueueEntryUpdater::removeJobs (BQEntryUpdateListener* listener)
             }
     }
 
-    qMutex->unlock ();
+    inactive.wait (lock, [this, listener] () { return activeListener != listener; });
 }
 
 void BatchQueueEntryUpdater::terminate  ()
@@ -230,5 +238,3 @@ void BatchQueueEntryUpdater::terminate  ()
 
     qMutex->unlock ();
 }
-
-

--- a/rtgui/bqentryupdater.h
+++ b/rtgui/bqentryupdater.h
@@ -18,6 +18,8 @@
  */
 #pragma once
 
+#include <condition_variable>
+
 #include <glibmm/thread.h>
 
 #include "hidpi.h"
@@ -62,6 +64,8 @@ protected:
     std::list<Job> jqueue;
     Glib::Thread* thread;
     MyMutex* qMutex;
+    std::condition_variable_any inactive;
+    BQEntryUpdateListener* activeListener;
 
 public:
     BatchQueueEntryUpdater ();


### PR DESCRIPTION
## Summary

Batch queue preview generation can deadlock while restoring a populated queue. The updater worker enters GTK after taking the preview lock, while drawing and layout can take those locks in the opposite order.

This schedules preview application on the GTK idle loop in [`BatchQueueEntry::updateImage`](https://github.com/zacharyvmm/RawTherapee/blob/85e80a30fd28f0909fd527e031de60eda8fc7665/rtgui/batchqueueentry.cc#L205-L218). [`BatchQueueEntry::_updateImage`](https://github.com/zacharyvmm/RawTherapee/blob/85e80a30fd28f0909fd527e031de60eda8fc7665/rtgui/batchqueueentry.cc#L220-L245) holds the preview lock only while replacing image data and requests the redraw after releasing it.

Entry destruction cancels queued idle work. [`BatchQueueEntryUpdater::removeJobs`](https://github.com/zacharyvmm/RawTherapee/blob/85e80a30fd28f0909fd527e031de60eda8fc7665/rtgui/bqentryupdater.cc#L190-L212) also waits for an active callback before the listener is destroyed, closing the race between scheduling the idle callback and removing the entry.

## Validation

Built the current commit in Release mode on Apple Silicon macOS. Restored a copied 63-item queue, waited for its previews to load, and scrolled through the queue. The GTK main loop remained responsive with no batch queue lock wait. This repository has no configured CTest tests.