### PR TITLE
Fixes some Gdk-Critical errors under Wayland by replacing deprecated Gtk::Menu::popup calls.

### DIFF
--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -216,9 +216,10 @@ int BatchQueue::getThumbnailHeight ()
     return std::max(std::min(App::get().options().thumbSizeQueue, 200), 10);
 }
 
-void BatchQueue::rightClicked ()
+void BatchQueue::rightClicked (int x, int y)
 {
-    pmenu.popup (3, this->eventTime);
+    const Gdk::Rectangle rect(x, y, 1, 1);
+    pmenu.popup_at_rect(internal.get_window(), rect, Gdk::GRAVITY_NORTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr);
 }
 
 void BatchQueue::doubleClicked(ThumbBrowserEntryBase* entry)

--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -1121,7 +1121,7 @@ Glib::ustring BatchQueue::autoCompleteFileName (const Glib::ustring& fileName, c
     return "";
 }
 
-void BatchQueue::buttonPressed (LWButton* button, int actionCode, void* actionData)
+void BatchQueue::buttonPressed (LWButton* button, int actionCode, void* actionData, int x, int y)
 {
     const std::vector<ThumbBrowserEntryBase*> bqe = {static_cast<BatchQueueEntry*>(actionData)};
 

--- a/rtgui/batchqueue.h
+++ b/rtgui/batchqueue.h
@@ -76,7 +76,7 @@ public:
     void error(const Glib::ustring& descr) override;
     rtengine::ProcessingJob* imageReady(rtengine::IImagefloat* img) override;
 
-    void rightClicked () override;
+    void rightClicked (int x, int y) override;
     void doubleClicked (ThumbBrowserEntryBase* entry) override;
     bool keyPressed (GdkEventKey* event) override;
     void buttonPressed (LWButton* button, int actionCode, void* actionData) override;

--- a/rtgui/batchqueue.h
+++ b/rtgui/batchqueue.h
@@ -79,7 +79,7 @@ public:
     void rightClicked (int x, int y) override;
     void doubleClicked (ThumbBrowserEntryBase* entry) override;
     bool keyPressed (GdkEventKey* event) override;
-    void buttonPressed (LWButton* button, int actionCode, void* actionData) override;
+    void buttonPressed (LWButton* button, int actionCode, void* actionData, int x, int y) override;
     void redrawNeeded  (LWButton* button) override;
     void selectionChanged () override;
 

--- a/rtgui/cropwindow.cc
+++ b/rtgui/cropwindow.cc
@@ -2372,7 +2372,7 @@ void CropWindow::zoomFitCrop ()
     }
 }
 
-void CropWindow::buttonPressed (LWButton* button, int actionCode, void* actionData)
+void CropWindow::buttonPressed (LWButton* button, int actionCode, void* actionData, int x, int y)
 {
 
     if (button == bZoomIn) { // zoom in

--- a/rtgui/cropwindow.h
+++ b/rtgui/cropwindow.h
@@ -218,7 +218,7 @@ public:
     void setEditSubscriber (EditSubscriber* newSubscriber);
 
     // interface lwbuttonlistener
-    void buttonPressed (LWButton* button, int actionCode, void* actionData) override;
+    void buttonPressed (LWButton* button, int actionCode, void* actionData, int x, int y) override;
     void redrawNeeded  (LWButton* button) override;
 
     // crop handling

--- a/rtgui/filebrowser.cc
+++ b/rtgui/filebrowser.cc
@@ -1777,7 +1777,7 @@ void FileBrowser::requestColorLabel(int colorlabel)
     colorlabelRequested (mselected, colorlabel);
 }
 
-void FileBrowser::buttonPressed (LWButton* button, int actionCode, void* actionData)
+void FileBrowser::buttonPressed (LWButton* button, int actionCode, void* actionData, int x, int y)
 {
 
     if (actionCode >= 0 && actionCode <= 5) { // rank
@@ -1801,7 +1801,8 @@ void FileBrowser::buttonPressed (LWButton* button, int actionCode, void* actionD
     } else if (actionCode == 8 && tbl) { // color label
         // show popup menu
         colorLabel_actionData = actionData;// this will be reused when pmenuColorLabels is clicked
-        pmenuColorLabels->popup (3, this->eventTime);
+        const Gdk::Rectangle rect(x, y, 1, 1);
+        pmenuColorLabels->popup_at_rect(internal.get_window(), rect, Gdk::GRAVITY_NORTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr);
     }
 }
 

--- a/rtgui/filebrowser.cc
+++ b/rtgui/filebrowser.cc
@@ -538,7 +538,7 @@ FileBrowser::~FileBrowser ()
     delete[] amiExtProg;
 }
 
-void FileBrowser::rightClicked ()
+void FileBrowser::rightClicked (int x, int y)
 {
 
     {
@@ -607,7 +607,8 @@ void FileBrowser::rightClicked ()
     cachesubmenu->show_all ();
     cachemenu->set_submenu (*cachesubmenu);
 
-    pmenu->popup (3, this->eventTime);
+    const Gdk::Rectangle rect(x, y, 1, 1);
+    pmenu->popup_at_rect(internal.get_window(), rect, Gdk::GRAVITY_NORTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr);
 }
 
 void FileBrowser::doubleClicked (ThumbBrowserEntryBase* entry)

--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -180,7 +180,7 @@ public:
     void buttonPressed (LWButton* button, int actionCode, void* actionData) override;
     void redrawNeeded  (LWButton* button) override;
     bool checkFilter (ThumbBrowserEntryBase* entry) const override;
-    void rightClicked () override;
+    void rightClicked (int x, int y) override;
     void doubleClicked (ThumbBrowserEntryBase* entry) override;
     bool keyPressed (GdkEventKey* event) override;
 

--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -177,7 +177,7 @@ public:
         return numFiltered;
     }
 
-    void buttonPressed (LWButton* button, int actionCode, void* actionData) override;
+    void buttonPressed (LWButton* button, int actionCode, void* actionData, int x, int y) override;
     void redrawNeeded  (LWButton* button) override;
     bool checkFilter (ThumbBrowserEntryBase* entry) const override;
     void rightClicked (int x, int y) override;

--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -999,7 +999,7 @@ void ThumbBrowserBase::buttonPressed (int x, int y, int button, GdkEventType typ
             }
 
             MYWRITERLOCK_RELEASE(l);
-            rightClicked ();
+            rightClicked (x, y);
         }
     } // end of MYWRITERLOCK(l, entryRW);
 

--- a/rtgui/thumbbrowserbase.h
+++ b/rtgui/thumbbrowserbase.h
@@ -228,7 +228,7 @@ public:
     {
         return true;
     }
-    virtual void rightClicked () = 0;
+    virtual void rightClicked (int x, int y) = 0;
     virtual void doubleClicked (ThumbBrowserEntryBase* entry) {}
     virtual bool keyPressed (GdkEventKey* event)
     {

--- a/rtgui/widgets/basic/lwbutton.cc
+++ b/rtgui/widgets/basic/lwbutton.cc
@@ -176,7 +176,7 @@ bool LWButton::releaseNotify (int x, int y)
     }
 
     if (action && listener) {
-        listener->buttonPressed (this, actionCode, actionData);
+        listener->buttonPressed (this, actionCode, actionData, x, y);
     }
 
     return ret;

--- a/rtgui/widgets/basic/lwbutton.h
+++ b/rtgui/widgets/basic/lwbutton.h
@@ -26,7 +26,7 @@ class LWButtonListener
 {
 public:
     virtual ~LWButtonListener() = default;
-    virtual void buttonPressed(LWButton* button, int actionCode, void* actionData)  = 0;
+    virtual void buttonPressed(LWButton* button, int actionCode, void* actionData, int x, int y)  = 0;
     virtual void redrawNeeded(LWButton* button) = 0;
 };
 

--- a/rtgui/widgets/basic/popupcommon.cc
+++ b/rtgui/widgets/basic/popupcommon.cc
@@ -304,7 +304,7 @@ void PopUpCommon::setButtonHint()
 void PopUpCommon::showMenu(GdkEventButton* event)
 {
     if (event->button == 1) {
-        menu->popup(event->button, event->time);
+        menu->popup_at_widget(arrowButton, Gdk::GRAVITY_SOUTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr);
     }
 }
 


### PR DESCRIPTION
RawTherapee opens some menus with `Gtk::Menu::open` call. This generates
```
Gdk-Message: 13:18:58.188: Window 0x106d48a0 is a temporary window without parent, application will not be able to position it on screen.

(rawtherapee:33870): Gdk-CRITICAL **: 13:18:58.230: gdk_wayland_window_handle_configure_popup: assertion 'impl->transient_for' failed
```
errors to the terminal when RawTherapee is run over Wayland. This PR substitutes these calls with more appropriate calls. The goal on this PR was to fix the errors without making it more difficult to migrate to Gtk4, where the menu logic will need to be rewritten completely. Please also notice, the currently used [popup](https://docs.gtk.org/gtk3/method.Menu.popup.html) has been deprecated.

There are couple minor behavior changes compared to the older implementation. The `PopUpCommon::showMenu` used by the tools, will no longer open the menu at the mouse pointer, but instead, the menu is aligned with the widget. Also, the menu can no longer be closed by clicking the down arrow again. The behavior with right mouse click menus should remain the same as before.

I'm not actually familiar with Gtk API. I used AI to consult me on the changes.

@digitalcarp You're the Gtk and Gtk migration guy here. Requesting review or comment from you.
