### PR TITLE
Skip the preview rescale when the zoom needs no resampling

### DIFF
--- a/rtgui/crophandler.cc
+++ b/rtgui/crophandler.cc
@@ -30,6 +30,35 @@
 
 using namespace rtengine;
 
+namespace
+{
+
+/**
+ * Produce one of the display pixbufs for the preview.
+ *
+ * czoom is exactly 1.0 for every zoom step whose percentage is an integer, i.e.
+ * for 1:1 and for all the "major" steps (50%, 33%, 25%, 20% ...), so it covers
+ * most of the zoom levels actually in use. gdk_pixbuf_scale() has no shortcut
+ * for that case: it still pushes every pixel through its filter machinery, for
+ * a result that is bit-identical to simply moving the pixels. Copying instead
+ * is several times cheaper, and this runs on the GUI thread on every preview
+ * refresh, so the difference is felt directly.
+ */
+Glib::RefPtr<Gdk::Pixbuf> resampleForDisplay (const Glib::RefPtr<Gdk::Pixbuf>& src, int width, int height, float czoom, bool unscaled)
+{
+    Glib::RefPtr<Gdk::Pixbuf> dest = Gdk::Pixbuf::create (Gdk::COLORSPACE_RGB, false, 8, width, height);
+
+    if (unscaled) {
+        src->copy_area (0, 0, width, height, dest, 0, 0);
+    } else {
+        src->scale (dest, 0, 0, width, height, 0, 0, czoom, czoom, Gdk::INTERP_TILES);
+    }
+
+    return dest;
+}
+
+}
+
 CropHandler::CropHandler() :
     cropParams(new procparams::CropParams),
     cropGuideParams(new procparams::CropGuideParams),
@@ -371,6 +400,11 @@ void CropHandler::setDetailedCrop(
                                     zoom / 1000.f :
                                     float((zoom/10) * 10) / float(zoom);
 
+                                // Tested on the integers czoom is derived from, so that the
+                                // no-resampling case is recognised exactly rather than by
+                                // comparing floats.
+                                const bool unscaled = zoom >= 1000 ? zoom == 1000 : zoom % 10 == 0;
+
                                 int imw = cropimg_width * czoom;
                                 int imh = cropimg_height * czoom;
 
@@ -383,13 +417,11 @@ void CropHandler::setDetailedCrop(
                                 }
 
                                 Glib::RefPtr<Gdk::Pixbuf> tmpPixbuf = Gdk::Pixbuf::create_from_data (cropimg.data(), Gdk::COLORSPACE_RGB, false, 8, cropimg_width, cropimg_height, 3 * cropimg_width);
-                                cropPixbuf = Gdk::Pixbuf::create (Gdk::COLORSPACE_RGB, false, 8, imw, imh);
-                                tmpPixbuf->scale (cropPixbuf, 0, 0, imw, imh, 0, 0, czoom, czoom, Gdk::INTERP_TILES);
+                                cropPixbuf = resampleForDisplay (tmpPixbuf, imw, imh, czoom, unscaled);
                                 tmpPixbuf.clear ();
 
                                 Glib::RefPtr<Gdk::Pixbuf> tmpPixbuftrue = Gdk::Pixbuf::create_from_data (cropimgtrue.data(), Gdk::COLORSPACE_RGB, false, 8, cropimg_width, cropimg_height, 3 * cropimg_width);
-                                cropPixbuftrue = Gdk::Pixbuf::create (Gdk::COLORSPACE_RGB, false, 8, imw, imh);
-                                tmpPixbuftrue->scale (cropPixbuftrue, 0, 0, imw, imh, 0, 0, czoom, czoom, Gdk::INTERP_TILES);
+                                cropPixbuftrue = resampleForDisplay (tmpPixbuftrue, imw, imh, czoom, unscaled);
                                 tmpPixbuftrue.clear ();
                             }
 


### PR DESCRIPTION
### What

`CropHandler::setDetailedCrop()` builds the two display pixbufs (`cropPixbuf` and `cropPixbuftrue`) with `Gdk::Pixbuf::scale(..., czoom, czoom, Gdk::INTERP_TILES)`. For a large share of the zoom steps `czoom` is exactly `1.0`, and `gdk_pixbuf_scale()` has no shortcut for that case — it still pushes every pixel through its filter machinery to produce a result that is bit-identical to simply copying the pixels.

This adds a `copy_area()` fast path for that case.

### Why it covers most zoom levels

`czoom` is `1.0` whenever the zoom percentage is an integer:

```cpp
float czoom = zoom >= 1000 ? zoom / 1000.f
                           : float((zoom/10) * 10) / float(zoom);
```

which is `zoom == 1000`, or `zoom % 10 == 0`. That is exactly the condition `CropWindow::initZoomSteps()` records as `is_major`:

```cpp
bool is_major = (s == s/10 * 10);                                  // cropwindow.cc:160
```

and `zoomIn()` / `zoomOut()` walk forward and back to the next `is_major` entry:

```cpp
while (z < int(zoomSteps.size()) && !zoomSteps[z].is_major) { ++z; }   // cropwindow.cc:2219
while (z >= 0 && !zoomSteps[z].is_major) { --z; }                      // cropwindow.cc:2244
```

So every zoom level reachable with the zoom buttons, the keyboard and the scroll wheel lands on it, as does 1:1. What still resamples, unchanged: "fit to window" (it snaps to an arbitrary step), the 1% step, and 200% and above, which are genuine upscales.

Both pixbufs are built on the GUI thread on every preview refresh, so the cost is paid where it is felt.

### Measurements

`gdk-pixbuf 2.44`, Apple M1, best of 20 runs, at the preview sizes a 6K display actually produces here (the 1920x2885 figure is the buffer size logged from a running editor):

| buffer (device px) | `scale(1.0, INTERP_TILES)` | `copy_area` | speedup | saved per refresh (both pixbufs) |
|---|---|---|---|---|
| 1920x2885 | 17.49 ms | 3.45 ms | 5.1x | 28.1 ms |
| 2348x1500 | 11.15 ms | 2.20 ms | 5.1x | 17.9 ms |
| 3200x2000 | 20.53 ms | 3.99 ms | 5.1x | 33.1 ms |
| 1600x1000 |  5.08 ms | 0.99 ms | 5.1x |  8.2 ms |

### Correctness

The two outputs were compared byte for byte at each of those sizes, over pseudo-random high-frequency content (worst case for a resampler): **0 differing bytes**. This changes no pixels.

The fast path is selected on an integer test on `zoom` rather than by comparing `czoom` against `1.0f`, so there is no float-equality question. `czoom == 1.0f` holds exactly in those cases anyway, since it is a division of two equal integers.

`copy_area` cannot run out of bounds: when the fast path is taken `imw`/`imh` start out equal to the source dimensions and are only ever clamped down to the window size.

### Testing

Built and run on macOS 26.5 / arm64 (clang, `-DWITH_SIMDE=ON`), gtkmm3 from Homebrew. Opened raw files in the editor, checked that the preview renders correctly and that the fast path is taken at the expected zoom levels. No new compiler warnings.

### Notes

This came out of profiling the editor on Apple Silicon looking for something to offload to the GPU. There is no GPU-shaped hotspot in the load path — on a 21 MP CR2, switching demosaic from AMaZE to `fast` moves the total by only ~0.09 s out of ~2.0 s, so the cost is spread thinly across the pipeline rather than concentrated anywhere. The display path, on the other hand, had this straightforward redundancy, and fixing it needs no platform-specific code at all.

Happy to split, reword or drop the comments if you would prefer them shorter.
