### PR TITLE
mac: fix numeric "-" entry with certain locales

### DIFF
--- a/tools/osx/Info.plist.in
+++ b/tools/osx/Info.plist.in
@@ -4,7 +4,9 @@
 <dict>
     <key>LSEnvironment</key>
     <dict>
-        <key>LC_ALL</key>
+        <key>LC_NUMERIC</key>
+        <string>C</string>
+        <key>LC_MONETARY</key>
         <string>C</string>
         <key>DYLD_FALLBACK_LIBRARY_PATH</key>
         <string>/Applications/RawTherapee.app/Contents/Frameworks</string>

--- a/tools/osx/Info.plist.in
+++ b/tools/osx/Info.plist.in
@@ -4,6 +4,8 @@
 <dict>
     <key>LSEnvironment</key>
     <dict>
+        <key>LC_ALL</key>
+        <string>C</string>
         <key>DYLD_FALLBACK_LIBRARY_PATH</key>
         <string>/Applications/RawTherapee.app/Contents/Frameworks</string>
         <key>XDG_CONFIG_DIRS</key>


### PR DESCRIPTION
Fixes #7745
The number entry boxes will inherit the C locale from Info.plist per @GaffaSnobb's workaround https://github.com/RawTherapee/RawTherapee/issues/7745#issue-5267366326
___ 
mac: Add LC_ALL=C environment variable to Info.plist